### PR TITLE
Added ability to work behind NAT for coturn (e.g. on EC2)

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -850,9 +850,9 @@ install_coturn() {
   if [ "$DIG_IP" != "$IP" ]; then err "DNS lookup for $COTURN_HOST resolved to $DIG_IP but didn't match local IP of $IP."; fi
   INTIP=$(hostname -I | cut -f1 -d' ')
   if [ "$DIG_IP" != "$INTIP" ]; then 
-    EXTIP=$(external-ip=$DIG_IP)
+    EXTIP="external-ip=$DIG_IP"
   else 
-    EXTIP="#external-ip=172.17.19.131"
+    EXTIP="#external ip not different to internal ip"
   fi
     
   apt-get update
@@ -889,8 +889,8 @@ tls-listening-port=443
 # If the server is behind NAT, you need to specify the external IP address.
 # If there is only one external address, specify it like this:
 #external-ip=172.17.19.120
-#This has been done for you - if the script detects that external-ip !=
-#internal-ip then it will set external-ip
+# If the line below is set with an external-ip, then the install script
+# detected external-ip != internal-ip.
 $EXTIP
 # If you have multiple external addresses, you have to specify which
 # internal address each corresponds to, like this. The first address is the

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -848,7 +848,13 @@ HERE
 install_coturn() {
   IP=$(wget -qO- http://169.254.169.254/latest/meta-data/public-ipv4 && echo)
   if [ "$DIG_IP" != "$IP" ]; then err "DNS lookup for $COTURN_HOST resolved to $DIG_IP but didn't match local IP of $IP."; fi
-
+  INTIP=$(hostname -I | cut -f1 -d' ')
+  if [ "$DIG_IP" != "$INTIP" ]; then 
+    EXTIP=$(external-ip=$DIG_IP)
+  else 
+    EXTIP="#external-ip=172.17.19.131"
+  fi
+    
   apt-get update
   apt-get -y -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" install grub-pc update-notifier-common
   apt-get dist-upgrade -yq
@@ -883,6 +889,9 @@ tls-listening-port=443
 # If the server is behind NAT, you need to specify the external IP address.
 # If there is only one external address, specify it like this:
 #external-ip=172.17.19.120
+#This has been done for you - if the script detects that external-ip !=
+#internal-ip then it will set external-ip
+$EXTIP
 # If you have multiple external addresses, you have to specify which
 # internal address each corresponds to, like this. The first address is the
 # external ip, and the second address is the corresponding internal IP.


### PR DESCRIPTION
Changes only affect TURN server install.
sets realm to the domain of the coturn hostname. Should this be the domain of the bbb-server? in which case might be more difficult/require more inputs.

detects whether external ip is different to internal ip in two way - the first checks there are no misconfigurations, the second checks is sort of a NAT check. if the test results true for NAT, then it sets external-ip on the server.
