### PR TITLE
Fix command to remove bbb-demo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ You can install the API demos by adding the `-a` option.
 wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -v xenial-220 -s bbb.example.com -e info@example.com -a
 ~~~
 
-Warning: These API demos allow anyone to access your server without authentication to create/manage meetings and recordings. They are for testing purposes only.  Once you are finished testing, you can remove the API demos with `sudo apt-get purge bbb-demos`.
+Warning: These API demos allow anyone to access your server without authentication to create/manage meetings and recordings. They are for testing purposes only.  Once you are finished testing, you can remove the API demos with `sudo apt-get purge bbb-demo`.
 
 
 ## Install Greenlight


### PR DESCRIPTION
Removed an extraneous 's' because the package is bbb-demo not bbb-demos.