### PR TITLE
Add Travis CI configuration using Ubuntu 16.04 and 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: generic
 
 jobs:
   include:
-  - dist: xenial
+  - name: Ubuntu 16.04 Xenial, BBB 2.2 with API
+    dist: xenial
+    script: sudo ./bbb-install.sh -v xenial-220 -a
+  - name: Ubuntu 16.04 Xenial, BBB 2.2 with API and Greenlight
+    dist: xenial
     script: sudo ./bbb-install.sh -v xenial-220 -a -g
-  - dist: bionic
-    script: sudo ./bbb-install.sh -v xenial-220 -a -g
+  - name: Ubuntu 18.04 Bionic, BBB 2.2 with API and Greenlight
+    dist: bionic
+    script: sudo ./bbb-install.sh -v bionic-220 -a -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: generic
 jobs:
   include:
   - dist: xenial
-    script: sudo ./bbb-install.sh -v xenial-223 -a -g
+    script: sudo ./bbb-install.sh -v xenial-220 -a -g
   - dist: bionic
-    script: sudo ./bbb-install.sh -v bionic-223 -a -g
+    script: sudo ./bbb-install.sh -v xenial-220 -a -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: generic
-dist: xenical
 
-script: sudo ./bbb-install.sh -v xenial-220 -a -g
+jobs:
+  include:
+  - dist: xenial
+    script: sudo ./bbb-install.sh -v xenial-220 -a -g
+  - dist: bionic
+    script: sudo ./bbb-install.sh -v bionic-220 -a -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: generic
 dist: xenical
 
-script: ./bbb-install.sh
+script: ./bbb-install.sh -v xenial-220 -a -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: generic
+dist: xenical
+
+script: ./bbb-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: generic
 jobs:
   include:
   - dist: xenial
-    script: sudo ./bbb-install.sh -v xenial-220 -a -g
+    script: sudo ./bbb-install.sh -v xenial-223 -a -g
   - dist: bionic
-    script: sudo ./bbb-install.sh -v bionic-220 -a -g
+    script: sudo ./bbb-install.sh -v bionic-223 -a -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: generic
 dist: xenical
 
-script: ./bbb-install.sh -v xenial-220 -a -g
+script: sudo ./bbb-install.sh -v xenial-220 -a -g


### PR DESCRIPTION
Adds a basic Travis CI configuration which runs `bbb-install.sh` with both the BBB API demos and Greenlight enabled. [Example run](https://travis-ci.com/github/EwoutH/bbb-install/builds/156356720).

There are a few issues however.

- First of all, the versioning scheme. Apparently 220 is is used for all 2.2.x releases, while you would expect 2.2.0, and 223 for the 2.2.3 release. Can this be resolved or at least made more clear in the documentation?
- Second of all, resources for bionic are non-existent while it looks like it's supported in the shell-script. Can these be added to [ubuntu.bigbluebutton.org](https://ubuntu.bigbluebutton.org/)?
- Third of all, it produces about [190 error and 140 warning messages](https://travis-ci.com/github/EwoutH/bbb-install/jobs/307992593) on a regular Ubuntu 16.04 server. How can those be resolved?