### PR TITLE
Fix race condition in get_IP

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -421,6 +421,7 @@ get_IP() {
     need_pkg netcat-openbsd
     nc -l -p 443 > /dev/null 2>&1 &
     nc_PID=$!
+    sleep 1
     
      # Check if we can reach the server through it's external IP address
      if nc -zvw3 $external_ip 443  > /dev/null 2>&1; then


### PR DESCRIPTION
Wait for a second after opening port 443 with `nc -l`, otherwise the follow-up check might be done before the port is up and IP recognition fails

(Happened in an AWS EC2 instance.)