### PR TITLE
allow coturn installation with provided ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ OPTIONS (install BigBlueButton):
 
 OPTIONS (install coturn):
 
+  -d                     Skip SSL certificates request (use provided certificates from mounted volume)
   -c <hostname>:<secret> Configure coturn with <hostname> and <secret> (required)
-  -e <email>             Email for Let's Encrypt certbot (required)
+  -e <email>             Email for Let's Encrypt certbot (required, without -d)
 
 
 EXAMPLES
@@ -161,7 +162,8 @@ Setup a BigBlueButton server
 
 Setup a coturn server
 
-    ./bbb-install.sh -c turn.example.com:1234324 -e info@example.com
+    ./bbb-install.sh    -c turn.example.com:1234324 -e info@example.com
+    ./bbb-install.sh -d -c turn.example.com:1234324
 
 SUPPORT:
      Source: https://github.com/bigbluebutton/bbb-install
@@ -402,6 +404,12 @@ wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -c turn.e
 ~~~
 
 `bbb-install.sh` uses Let's Encrypt to configure coturn to use a SSL certificate.  With a SSL certificate in place, coturn can relay access to your BigBlueButton server via TCP/IP on port 443.  This means if a user is behind a restrictive firewall that blocks all outgoing UDP connections, the TURN server can accept connections from the user via TCP/IP on port 443 and relay the data to your BigBlueButton server via UDP.
+
+To use provided SSL certificates from mounted volume, put the option `-d` in front of `-c` and omit the `-e` option.
+
+~~~
+wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -d -c turn.example.com:1234abcd
+~~~
 
 With the TURN server in place, you can configure your BigBlueButton server to use the TURN server by running the `bbb-install.sh` command again and adding the same `-c <FQDN>:<SECRET>`.  For example,
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -77,6 +77,7 @@ OPTIONS (install BigBlueButton):
 
 OPTIONS (install coturn only):
 
+  -d                     Skip SSL certificates request (use provided certificates from mounted volume)
   -c <hostname>:<secret> Setup a coturn server with <hostname> and <secret> (required)
   -e <email>             Configure email for Let's Encrypt certbot (required)
 
@@ -100,6 +101,7 @@ Sample options for setup a BigBlueButton server
 Sample options for setup of a coturn server (on a different server)
 
     -c turn.example.com:1234324 -e info@example.com
+    -d -c turn.example.com:1234324
 
 SUPPORT:
     Community: https://bigbluebutton.org/support
@@ -200,7 +202,7 @@ main() {
 
   # Check if we're installing coturn (need an e-mail address for Let's Encrypt)
   if [ -z "$VERSION" ] && [ ! -z "$COTURN" ]; then
-    if [ -z "$EMAIL" ]; then err "Installing coturn needs an e-mail address for Let's Encrypt"; fi
+    if [ -z "$EMAIL" ] && [ -z "$PROVIDED_CERTIFICATE" ]; then err "Installing coturn needs an e-mail address for Let's Encrypt, or -d Skip SSL certificates"; fi
     check_ubuntu 18.04
 
     install_coturn
@@ -988,14 +990,21 @@ install_coturn() {
   apt-get dist-upgrade -yq
   need_pkg coturn
 
-  need_pkg software-properties-common 
-  need_ppa certbot-ubuntu-certbot-bionic.list ppa:certbot/certbot 75BCA694 7BF5
-  apt-get -y install certbot
+  need_pkg software-properties-common
+  if [ -z "$PROVIDED_CERTIFICATE" ] ; then
+      need_ppa certbot-ubuntu-certbot-bionic.list ppa:certbot/certbot 75BCA694 7BF5
+      apt-get -y install certbot
 
-  if ! certbot certonly --standalone --non-interactive --preferred-challenges http \
+      if ! certbot certonly --standalone --non-interactive --preferred-challenges http \
          --deploy-hook "systemctl restart coturn" \
          -d $COTURN_HOST --email $EMAIL --agree-tos -n ; then
-     err "Let's Encrypt SSL request for $COTURN_HOST did not succeed - exiting"
+         err "Let's Encrypt SSL request for $COTURN_HOST did not succeed - exiting"
+      fi
+  else
+      say "Using provided ssl from /local/certs/"
+      mkdir -p /etc/letsencrypt/live/$COTURN_HOST/
+      ln -fs /local/certs/fullchain.pem /etc/letsencrypt/live/$COTURN_HOST/fullchain.pem
+      ln -fs /local/certs/privkey.pem /etc/letsencrypt/live/$COTURN_HOST/privkey.pem
   fi
 
   COTURN_REALM=$(echo $COTURN_HOST | cut -d'.' -f2-)


### PR DESCRIPTION
Hi, this little patch enhance bbb-install.sh to
- install a coturn server with provided ssl.
- suppress call to let's encrypt in this case