### PR TITLE
Update nginx SSL/TLS protocols and ciphers

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -804,8 +804,8 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/$HOST/privkey.pem;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS:!AES256";
+    ssl_protocols TLSv1.2;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers on;
     ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
 


### PR DESCRIPTION
Harden the nginx ssl config.

Based on https://ssl-config.mozilla.org/#server=nginx&version=1.10.3&config=intermediate&openssl=1.0.2g&ocsp=false&guideline=5.4
openssl and nginx version met the ubuntu 16.04. versions