### PR TITLE
Fixed typo in dummy service

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -586,7 +586,7 @@ WantedBy=multi-user.target
 HERE
 
       if [ "$DAEMON_RELOAD" == "true" ]; then
-        systemctl dameon-reload
+        systemctl daemon-reload
         systemctl restart dummy-nic
       else
         systemctl enable dummy-nic


### PR DESCRIPTION
daemon-reload was typed dameon-reload, this commit is fixing this typo