### PR TITLE
nginx privacy: disable access_log, enable error_log

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -759,7 +759,8 @@ server {
   listen [::]:80;
   server_name $HOST;
 
-  access_log  /var/log/nginx/bigbluebutton.access.log;
+  error_log /var/log/nginx/bigbluebutton.error.log;
+  access_log /dev/null;
 
   # BigBlueButton landing page.
   location / {
@@ -811,7 +812,8 @@ server {
     ssl_prefer_server_ciphers on;
     ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
 
-  access_log  /var/log/nginx/bigbluebutton.access.log;
+  error_log /var/log/nginx/bigbluebutton.error.log;
+  access_log /dev/null;
 
    # Handle RTMPT (RTMP Tunneling).  Forwards requests
    # to Red5 on port 5080


### PR DESCRIPTION
### What does this PR do?
- Disabled `access_log` for nginx in the bbb site-available file by setting log target `/dev/null`
- Enabled `error_log` for nginx in the bbb site-available file, so that errors and critical exceptions of nginx are still logged

### Motivation
- improve data privacy by default (this is also a suggested change from https://docs.bigbluebutton.org/admin/privacy.html )
- in case the access_log is temporarily needed (for example during a DDoS), the nginx configuration can easily be changed and applied without the need to restart nginx.