### PR TITLE
Apt get improvements

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -129,7 +129,6 @@ main() {
         if [ "$HOST" == "bbb.example.com" ]; then 
           err "You must specify a valid hostname (not the hostname given in the docs)."
         fi
-        check_host $HOST
         ;;
       r)
         PACKAGE_REPOSITORY=$OPTARG
@@ -149,7 +148,6 @@ main() {
         ;;
       v)
         VERSION=$OPTARG
-        check_version $VERSION
         ;;
 
       p)
@@ -188,6 +186,14 @@ main() {
 
   if [ ! -z "$PROXY" ]; then
     echo "Acquire::http::Proxy \"http://$PROXY:3142\";"  > /etc/apt/apt.conf.d/01proxy
+  fi
+
+  if [ ! -z "$HOST" ]; then
+    check_host $HOST
+  fi
+
+  if [ ! -z "$VERSION" ]; then
+    check_version $VERSION
   fi
 
   # Check if we're installing coturn (need an e-mail address for Let's Encrypt)

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -112,6 +112,7 @@ main() {
   export DEBIAN_FRONTEND=noninteractive
   PACKAGE_REPOSITORY=ubuntu.bigbluebutton.org
   LETS_ENCRYPT_OPTIONS="--webroot --non-interactive"
+  SOURCES_FETCHED=false
 
   need_x64
 
@@ -441,6 +442,11 @@ get_IP() {
 
 need_pkg() {
   check_root
+
+  if [ ! "$SOURCES_FETCHED" = true ]; then
+    apt-get update
+    SOURCES_FETCHED=true
+  fi
 
   if ! dpkg -s ${@:1} >/dev/null 2>&1; then
     LC_CTYPE=C.UTF-8 apt-get install -yq ${@:1}


### PR DESCRIPTION
Resolves #220 

Also resolves an issue, that apt-get commands could be called before setting up an apt-get proxy (if provided).