### PR TITLE
Fix broken anchors url to correct header

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The command will pull down the latest version of `bbb-install.sh`, send it to th
   * `-a` which specifies want to install the API demos (this makes it easy to do a few quick tests on the server), and 
   * `-w` which installs the uncomplicated firewall (UFW) to restrict access to TCP/IP ports 22, 80, and 443, and UDP ports in range 16384-32768.
 
-Note: If your server is also behind an external firewall -- such as behind a corporate firewall or behind an AWS Security Group -- you will need to manually configure the external firewall to forward [specific internet connections](#configuring-the-firewall) to the BigBlueButton server before you can launch the client.
+Note: If your server is also behind an external firewall -- such as behind a corporate firewall or behind an AWS Security Group -- you will need to manually configure the external firewall to forward [specific internet connections](#configuring-the-external-firewall) to the BigBlueButton server before you can launch the client.
 
 When `bbb-install.sh` finishes, you'll see a message that gives you a test URL to launch the BigBlueButton client and join a meeting called 'Demo Meeting'.  
 
@@ -478,4 +478,4 @@ If you encounter an error with the script (such as it not completing or throwing
 
 # Limitations
 
-If you are running your BigBlueButton behind a firewall, such as on EC2, this script will not configure your firewall.  You'll need to [configure the firewall](#configuring-the-firewall) manually.
+If you are running your BigBlueButton behind a firewall, such as on EC2, this script will not configure your firewall.  You'll need to [configure the firewall](#configuring-the-external-firewall) manually.


### PR DESCRIPTION
Fix broken anchor URLs found in readme to point to correct headers. The current header had the word 'external' added in https://github.com/bigbluebutton/bbb-install/commit/f0ef33485684865a15c297e97992c88603daae17 thus broke the anchors which were pointing to the older header.