### PR TITLE
Update bbb-install.sh

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -514,7 +514,7 @@ check_version() {
 }
 
 check_host() {
-  if [ -z "$PROVIDED_CERTIFICATE" ]; then
+  if [ -z "$PROVIDED_CERTIFICATE" ] && [ -z "$HOST" ]; then
     need_pkg dnsutils apt-transport-https net-tools
     DIG_IP=$(dig +short $1 | grep '^[.0-9]*$' | tail -n1)
     if [ -z "$DIG_IP" ]; then err "Unable to resolve $1 to an IP address using DNS lookup.";  fi


### PR DESCRIPTION
Fix issue 179: Avoid external IP with internal IP check since a hostname is used
https://github.com/bigbluebutton/bbb-install/issues/179

This pull request is related to issue #179. If one select with option **-s** a hostname, the IP check should be skipped.
Thanks to @derek-shnosh for mentioning how to solve this issue.

If this fix is not correct, please explain why and post a solution in #179 

Thanks!