### PR TITLE
Fix audio and video issues when NAT is not selected

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -514,7 +514,7 @@ check_version() {
 }
 
 check_host() {
-  if [ -z "$PROVIDED_CERTIFICATE" ]; then
+  if [ -z "$PROVIDED_CERTIFICATE" ] && [ -z "$HOST" ]; then
     need_pkg dnsutils apt-transport-https net-tools
     DIG_IP=$(dig +short $1 | grep '^[.0-9]*$' | tail -n1)
     if [ -z "$DIG_IP" ]; then err "Unable to resolve $1 to an IP address using DNS lookup.";  fi

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -514,7 +514,7 @@ check_version() {
 }
 
 check_host() {
-  if [ -z "$PROVIDED_CERTIFICATE" ] && [ -z "$HOST" ]; then
+  if [ -z "$PROVIDED_CERTIFICATE" ] && [ -z "$HOST" ] && [ -z "$COTURN" ]; then
     need_pkg dnsutils apt-transport-https net-tools
     DIG_IP=$(dig +short $1 | grep '^[.0-9]*$' | tail -n1)
     if [ -z "$DIG_IP" ]; then err "Unable to resolve $1 to an IP address using DNS lookup.";  fi

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1042,7 +1042,7 @@ install_coturn() {
   COTURN_REALM=$(echo $COTURN_HOST | cut -d'.' -f2-)
   
   if [ -z $IP ]; then
-    COMMENT_EXTERNAL_IP="#"
+    COMMENT_EXTERNAL_IP="#external-ip="
   else
     COMMENT_EXTERNAL_IP="external-ip="
   fi


### PR DESCRIPTION
If Nat is not selected, the configuration in the turn server is still setting the external-ip variable but to an empty value.
This causes 1007 ICE errors if the server is accessed behind a firewall. Further, it causes 1020 errors when trying to share the webcam.

I added an option that comments out the external-ip if NAT is not used. Further, this fix will ignore the internal-external-IP-check if the turn server is configured.

This fix might be related to the issues users experienced in #7321 and #8418 when using a turn server. I assume this fix is directly connected to #175 