### PR TITLE
Install net-tools if missing (required for 18.04LTS)

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -409,6 +409,7 @@ get_IP() {
   if [ ! -z "$IP" ]; then return 0; fi
 
   # Determine local IP
+  need_pkg net-tools
   if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
   else


### PR DESCRIPTION
### What does this PR do?
Install net-tools required in get_IP function of `bbb-install.sh` and `bbb-conf --check`

### Motivation
As suggested [here](https://github.com/bigbluebutton/bbb-install/issues/248#issuecomment-673770144).