### PR TITLE
The first element of "hostname -I" is not intended to receive the primary IP address

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -415,7 +415,7 @@ get_IP() {
   if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
   else
-    IP=$(hostname -I | cut -f1 -d' ')
+    IP=$(ifconfig `route | grep ^default | sed "s/.* //"` | grep -Po '(?<=inet addr:)[\d.]+')
   fi
 
   # Determine external IP 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -415,7 +415,7 @@ get_IP() {
   if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
   else
-    IP=$(ifconfig `route | grep ^default | sed "s/.* //"` | grep -Po '(?<=inet addr:)[\d.]+')
+	IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
   fi
 
   # Determine external IP 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -415,7 +415,7 @@ get_IP() {
   if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
   else
-	IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
+    IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
   fi
 
   # Determine external IP 


### PR DESCRIPTION
from the hostname manual: "Do not make any assumptions about the order of the output." 

Other interfaces, like Docker bridges tend to be first in line in "hostname -I", which will result in a malconfigured BBB. 

This change determines the primary interface by looking up the primary device of the default route.