### PR TITLE
Systemd failed to parse resource value

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -666,7 +666,6 @@ check_LimitNOFILE() {
       mkdir -p /etc/systemd/system/bbb-web.service.d/
       cat > /etc/systemd/system/bbb-web.service.d/override.conf << HERE
 [Service]
-LimitNOFILE=
 LimitNOFILE=8192
 HERE
       systemctl daemon-reload


### PR DESCRIPTION
```
[/etc/systemd/system/bbb-web.service.d/override.conf:2] Failed to parse resource value, ignoring:
```