### PR TITLE
fix check_LimitNOFILE

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -666,7 +666,7 @@ HERE
 check_LimitNOFILE() {
   CPU=$(nproc --all)
 
-  if [ "$CPU" -gt 8 ]; then
+  if [ "$CPU" -ge 8 ]; then
     if [ -f /lib/systemd/system/bbb-web.service ]; then
       # Let's create an override file to increase the number of LimitNOFILE 
       mkdir -p /etc/systemd/system/bbb-web.service.d/


### PR DESCRIPTION
check_LimitNOFILE only sets LimitNOFILE if you have more than 8 CPU cores available. 
But would also make sense with exactly 8 cores.