### PR TITLE
handle multiple default routes

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -440,7 +440,7 @@ get_IP() {
   if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
   else
-    IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
+    IP=$(ifconfig $(route | grep ^default | head -1 | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
   fi
 
   # Determine external IP 


### PR DESCRIPTION
The IP address detection logic is currently based on the assumption that there is a single default route.

Sometimes there are multiple default routes.  This patch picks the first default route, which (I think) will be the primary default route.

`route` displays the kernel routing table in the order it appears in `/proc/net/route`.  I assume that the kernel routing table is sorted so that the highest priority route comes first.

