### PR TITLE
only wait on local port 443

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -434,8 +434,9 @@ need_x64() {
 
 wait_443() {
   echo "Waiting for port 443 to clear "
-  while netstat -antp | grep TIME_WAIT | grep -q ":443"; do sleep 1; echo -n '.'; done
-  echo 
+  # netstat fields 4 and 6 are Local Address and State
+  while netstat -ant | awk '{print $4, $6}' | grep TIME_WAIT | grep -q ":443"; do sleep 1; echo -n '.'; done
+  echo
 }
 
 get_IP() {


### PR DESCRIPTION
At the point in the script where we check that the host is reachable on its port 443, we stop `nginx`, then wait for port 443 to clear before starting `nc` (listening on 443).

We only need to wait for the local port 443 to clear.  I've found that this step can stall for a while if there are outstanding connections to remote port 443s.

This patch changes the script so that only the local address field is checked for port 443, by adding an `awk` in the pipeline.

I'll note that `awk` is already used elsewhere in the script, so this doesn't introduce any new dependencies.
