### PR TITLE
parametrize turn server port 

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -93,11 +93,11 @@ Sample options for setup a BigBlueButton server
     -v xenial-22
     -v xenial-22 -s bbb.example.com -e info@example.com
     -v xenial-22 -s bbb.example.com -e info@example.com -g
-    -v xenial-22 -s bbb.example.com -e info@example.com -g -c turn.example.com:1234324:443
+    -v xenial-22 -s bbb.example.com -e info@example.com -g -c turn.example.com:443:1234324
 
 Sample options for setup of a coturn server (on a different server)
 
-    -c turn.example.com:1234324:443 -e info@example.com
+    -c turn.example.com:443:1234324 -e info@example.com
 
 SUPPORT:
     Community: https://bigbluebutton.org/support

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -60,7 +60,7 @@ OPTIONS (install BigBlueButton):
 
   -a                     Install BBB API demos
   -g                     Install Greenlight
-  -c <hostname>:<secret>:<port> Configure with coturn server at <hostname> listen on <port> using <secret>
+  -c <hostname>:<port>:<secret> Configure with coturn server at <hostname> listen on <port> using <secret>
 
   -m <link_path>         Create a Symbolic link from /var/bigbluebutton to <link_path> 
 
@@ -75,7 +75,7 @@ OPTIONS (install BigBlueButton):
 
 OPTIONS (install coturn only):
 
-  -c <hostname>:<secret>:<port> Setup a coturn server with <hostname> listen on <port> using <secret> (required)
+  -c <hostname>:<port>:<secret> Setup a coturn server with <hostname> listen on <port> using <secret> (required)
   -e <email>             Configure email for Let's Encrypt certbot (required)
 
 OPTIONS (install Let's Encrypt certificate only):
@@ -579,18 +579,25 @@ check_coturn() {
   if ! echo $1 | grep -q ':'; then err "Option for coturn must be <hostname>:<secret>"; fi
 
   COTURN_HOST=$(echo $OPTARG | cut -d':' -f1)
-  COTURN_SECRET=$(echo $OPTARG | cut -d':' -f2)
-  COTURN_PORT=$(echo $OPTARG | cut -d':' -f3)
-
+  COTURN_PORT=$(echo $OPTARG | cut -d':' -f2)
+  COTURN_SECRET=$(echo $OPTARG | cut -d':' -f3)
+  
   if [ -z "$COTURN_HOST" ];   then err "-c option must contain <hostname>"; fi
-  if [ -z "$COTURN_SECRET" ]; then err "-c option must contain <secret>"; fi
-  if [ -z "$COTURN_PORT" ]; then COTURN_PORT=443; fi
 
+  if [ -z "$COTURN_SECRET" ]; then
+    COTURN_SECRET="$COTURN_PORT"
+    COTURN_PORT=443
+  fi
+  if [ -z "$COTURN_SECRET" ]; then err "-c option must contain <secret>"; fi
+  
   if [ "$COTURN_HOST" == "turn.example.com" ]; then 
     err "You must specify a valid hostname (not the example given in the docs)"
   fi
   if [ "$COTURN_SECRET" == "1234324" ]; then
     err "You must specify a new password (not the example given in the docs)."
+  fi
+  if [ "$COTURN_SECRET" == "443" ]; then
+    err "You must specify a password. It looks like you have specify a port as secret."
   fi
 
   check_host $COTURN_HOST

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -589,7 +589,7 @@ check_coturn() {
   if [ "$COTURN_HOST" == "turn.example.com" ]; then 
     err "You must specify a valid hostname (not the example given in the docs)"
   fi
-  if [ "$COTURN_SECRET" == "12341234" ]; then 
+  if [ "$COTURN_SECRET" == "1234324" ]; then
     err "You must specify a new password (not the example given in the docs)."
   fi
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -60,7 +60,7 @@ OPTIONS (install BigBlueButton):
 
   -a                     Install BBB API demos
   -g                     Install Greenlight
-  -c <hostname>:<secret> Configure with coturn server at <hostname> using <secret>
+  -c <hostname>:<secret>:<port> Configure with coturn server at <hostname> listen on <port> using <secret>
 
   -m <link_path>         Create a Symbolic link from /var/bigbluebutton to <link_path> 
 
@@ -75,7 +75,7 @@ OPTIONS (install BigBlueButton):
 
 OPTIONS (install coturn only):
 
-  -c <hostname>:<secret> Setup a coturn server with <hostname> and <secret> (required)
+  -c <hostname>:<secret>:<port> Setup a coturn server with <hostname> listen on <port> using <secret> (required)
   -e <email>             Configure email for Let's Encrypt certbot (required)
 
 OPTIONS (install Let's Encrypt certificate only):
@@ -93,11 +93,11 @@ Sample options for setup a BigBlueButton server
     -v xenial-22
     -v xenial-22 -s bbb.example.com -e info@example.com
     -v xenial-22 -s bbb.example.com -e info@example.com -g
-    -v xenial-22 -s bbb.example.com -e info@example.com -g -c turn.example.com:1234324
+    -v xenial-22 -s bbb.example.com -e info@example.com -g -c turn.example.com:1234324:443
 
 Sample options for setup of a coturn server (on a different server)
 
-    -c turn.example.com:1234324 -e info@example.com
+    -c turn.example.com:1234324:443 -e info@example.com
 
 SUPPORT:
     Community: https://bigbluebutton.org/support
@@ -580,14 +580,16 @@ check_coturn() {
 
   COTURN_HOST=$(echo $OPTARG | cut -d':' -f1)
   COTURN_SECRET=$(echo $OPTARG | cut -d':' -f2)
+  COTURN_PORT=$(echo $OPTARG | cut -d':' -f3)
 
   if [ -z "$COTURN_HOST" ];   then err "-c option must contain <hostname>"; fi
   if [ -z "$COTURN_SECRET" ]; then err "-c option must contain <secret>"; fi
+  if [ -z "$COTURN_PORT" ]; then COTURN_PORT=443; fi
 
   if [ "$COTURN_HOST" == "turn.example.com" ]; then 
     err "You must specify a valid hostname (not the example given in the docs)"
   fi
-  if [ "$COTURN_SECRET" == "1234abcd" ]; then 
+  if [ "$COTURN_SECRET" == "12341234" ]; then 
     err "You must specify a new password (not the example given in the docs)."
   fi
 
@@ -1013,13 +1015,13 @@ configure_coturn() {
 
     <bean id="turn0" class="org.bigbluebutton.web.services.turn.TurnServer">
         <constructor-arg index="0" value="$COTURN_SECRET"/>
-        <constructor-arg index="1" value="turns:$COTURN_HOST:443?transport=tcp"/>
+        <constructor-arg index="1" value="turns:$COTURN_HOST:${COTURN_PORT}?transport=tcp"/>
         <constructor-arg index="2" value="86400"/>
     </bean>
     
     <bean id="turn1" class="org.bigbluebutton.web.services.turn.TurnServer">
         <constructor-arg index="0" value="$COTURN_SECRET"/>
-        <constructor-arg index="1" value="turn:$COTURN_HOST:443?transport=tcp"/>
+        <constructor-arg index="1" value="turn:$COTURN_HOST:${COTURN_PORT}?transport=tcp"/>
         <constructor-arg index="2" value="86400"/>
     </bean>
 
@@ -1075,7 +1077,7 @@ install_coturn() {
 
   cat <<HERE > /etc/turnserver.conf
 listening-port=3478
-tls-listening-port=443
+tls-listening-port=${COTURN_PORT}
 
 listening_ip=$IP
 relay_ip=$IP
@@ -1176,4 +1178,3 @@ HERE
 }
 
 main "$@" || exit 1
-


### PR DESCRIPTION
Not every turn server is listening on port 443. So it would be great, if it can be specified via command line parameter.