### PR TITLE
Reloading nginx in the certbot hook is sufficient

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -870,7 +870,7 @@ HERE
 
     if [ -z "$PROVIDED_CERTIFICATE" ]; then
       if ! certbot --email $EMAIL --agree-tos --rsa-key-size 4096 -w /var/www/bigbluebutton-default/ \
-           -d $HOST --deploy-hook "systemctl restart nginx" $LETS_ENCRYPT_OPTIONS certonly; then
+           -d $HOST --deploy-hook "systemctl reload nginx" $LETS_ENCRYPT_OPTIONS certonly; then
         cp /tmp/bigbluebutton.bak /etc/nginx/sites-available/bigbluebutton
         systemctl restart nginx
         err "Let's Encrypt SSL request for $HOST did not succeed - exiting"


### PR DESCRIPTION
Restarting on the other hand may
- lead to a downtime long enough to be noticed by monitoring
- break nginx in prod if the the server is in a state
  where nginx -t will report an error