### PR TITLE
Remove auto acceptance of ttf-mscorefonts

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -237,8 +237,6 @@ main() {
 
   get_IP $HOST
 
-  echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
-
   need_pkg curl
 
   if [ "$DISTRO" == "xenial" ]; then 


### PR DESCRIPTION
As stated in https://github.com/bigbluebutton/bigbluebutton/pull/12187 we should not auto accept this EULA.

A sysadmin can install these fonts manually later, but as default installation we should not use it.