### PR TITLE
omit -a instead of -v

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note the web pages are served via HTTPS.  The browsers now require this before a
 
 The hostname `bbb.example.com` and email address `info@example.com` are just sample parameters.  The following sections walk you through the details on using `bbb-install.sh` to setup/upgrade your BigBlueButton server.
 
-After testing, you can remove the api demos with the command `sudo apt-get purge bbb-demo`.  Later on, you can upgrade the server to the latest release of BigBlueButton 2.3 by re-running the same `bbb-install.sh` command, and omit the `-v` to install the API demos.
+After testing, you can remove the api demos with the command `sudo apt-get purge bbb-demo`.  Later on, you can upgrade the server to the latest release of BigBlueButton 2.3 by re-running the same `bbb-install.sh` command, and omit the `-a` to install the API demos.
 
 The following sections go through in more detail setting up a new BigBlueButton 2.3 server.
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ If you want to set up BigBlueButton 2.3 with a TLS/SSL certificate and GreenLigh
 wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -v bionic-23 -s bbb.example.com -e info@example.com -w -g
 ~~~
 
-Furthermore, you can re-run the same command later to update your server to the latest version of BigBlueButton 2.2.  We announce BigBlueButton updates to the [bigbluebutton-dev](https://groups.google.com/forum/#!forum/bigbluebutton-dev) mailing list.
+Furthermore, you can re-run the same command later to update your server to the latest version of BigBlueButton 2.3.  We announce BigBlueButton updates to the [bigbluebutton-dev](https://groups.google.com/forum/#!forum/bigbluebutton-dev) mailing list.
 
 
 ### Install a TURN server


### PR DESCRIPTION
Don't install api demos by omitting -a instead of -v (which is used for setting the build to install)