### PR TITLE
Fix issue #405 (1/1)

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -862,7 +862,7 @@ HERE
 
     if [ -z "$PROVIDED_CERTIFICATE" ]; then
       if ! certbot --email $EMAIL --agree-tos --rsa-key-size 4096 -w /var/www/bigbluebutton-default/ \
-           -d $HOST --deploy-hook "systemctl restart nginx" $LETS_ENCRYPT_OPTIONS certonly; then
+           -d $HOST --deploy-hook "systemctl reload nginx" $LETS_ENCRYPT_OPTIONS certonly; then
         systemctl restart nginx
         err "Let's Encrypt SSL request for $HOST did not succeed - exiting"
       fi


### PR DESCRIPTION
The patch modifies the generated certbot renewal hook to reload nginx
after a certificate renewal instead of restarting nginx.  Users will not
need to reconnect their webcams and microphones after a certificate
renewal takes place.