### PR TITLE
Fix double quote shellcheck errors

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -140,7 +140,7 @@ main() {
         ;;
       c)
         COTURN=$OPTARG
-        check_coturn $COTURN
+        check_coturn "$COTURN"
         ;;
       v)
         VERSION=$OPTARG
@@ -189,11 +189,11 @@ main() {
   done
 
   if [ ! -z "$HOST" ]; then
-    check_host $HOST
+    check_host "$HOST"
   fi
 
   if [ ! -z "$VERSION" ]; then
-    check_version $VERSION
+    check_version "$VERSION"
   fi
 
   check_apache2
@@ -229,7 +229,7 @@ main() {
   sudo add-apt-repository universe
   need_pkg wget curl gpg-agent dirmngr
 
-  get_IP $HOST
+  get_IP "$HOST"
 
   if [ "$DISTRO" == "xenial" ]; then 
     echo "** Ubuntu 16.04 is now end of life.  Recommend installing BigBlueButton 2.3 on Ubuntu 18.04"
@@ -395,9 +395,9 @@ HERE
   fi
 
   if [ ! -z "$HOST" ]; then
-    bbb-conf --setip $HOST
+    bbb-conf --setip "$HOST"
   else
-    bbb-conf --setip $IP
+    bbb-conf --setip "$IP"
   fi
 
   if ! systemctl show-environment | grep LANG= | grep -q UTF-8; then
@@ -428,7 +428,7 @@ check_mem() {
 
 check_ubuntu(){
   RELEASE=$(lsb_release -r | sed 's/^[^0-9]*//g')
-  if [ "$RELEASE" != $1 ]; then err "You must run this command on Ubuntu $1 server."; fi
+  if [ "$RELEASE" != "$1" ]; then err "You must run this command on Ubuntu $1 server."; fi
 }
 
 need_x64() {
@@ -470,7 +470,7 @@ get_IP() {
   elif [ ! -z "$1" ]; then
     # Try and determine the external IP from the given hostname
     need_pkg dnsutils
-    local external_ip=$(dig +short $1 @resolver1.opendns.com | grep '^[.0-9]*$' | tail -n1)
+    local external_ip=$(dig +short "$1" @resolver1.opendns.com | grep '^[.0-9]*$' | tail -n1)
   fi
 
   # Check if the external IP reaches the internal IP
@@ -488,7 +488,7 @@ get_IP() {
     sleep 1
     
      # Check if we can reach the server through it's external IP address
-     if nc -zvw3 $external_ip 443  > /dev/null 2>&1; then
+     if nc -zvw3 "$external_ip" 443  > /dev/null 2>&1; then
        INTERNAL_IP=$IP
        IP=$external_ip
        echo 
@@ -524,33 +524,33 @@ need_pkg() {
 
 need_ppa() {
   need_pkg software-properties-common 
-  if [ ! -f /etc/apt/sources.list.d/$1 ]; then
-    LC_CTYPE=C.UTF-8 add-apt-repository -y $2 
+  if [ ! -f "/etc/apt/sources.list.d/$1" ]; then
+    LC_CTYPE=C.UTF-8 add-apt-repository -y "$2"
   fi
-  if ! apt-key list $3 | grep -q -E "1024|4096"; then  # Let's try it a second time
-    LC_CTYPE=C.UTF-8 add-apt-repository $2 -y
-    if ! apt-key list $3 | grep -q -E "1024|4096"; then
+  if ! apt-key list "$3" | grep -q -E "1024|4096"; then  # Let's try it a second time
+    LC_CTYPE=C.UTF-8 add-apt-repository "$2" -y
+    if ! apt-key list "$3" | grep -q -E "1024|4096"; then
       err "Unable to setup PPA for $2"
     fi
   fi
 }
 
 check_version() {
-  if ! echo $1 | egrep -q "xenial|bionic"; then err "This script can only install BigBlueButton 2.2 (or later)"; fi
-  DISTRO=$(echo $1 | sed 's/-.*//g')
+  if ! echo "$1" | egrep -q "xenial|bionic"; then err "This script can only install BigBlueButton 2.2 (or later)"; fi
+  DISTRO=$(echo "$1" | sed 's/-.*//g')
   if ! wget -qS --spider "https://$PACKAGE_REPOSITORY/$1/dists/bigbluebutton-$DISTRO/Release.gpg" > /dev/null 2>&1; then
     err "Unable to locate packages for $1 at $PACKAGE_REPOSITORY."
   fi
   check_root
   need_pkg apt-transport-https
   if ! apt-key list | grep -q "BigBlueButton apt-get"; then
-    wget https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc -O- | apt-key add -
+    wget "https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc" -O- | apt-key add -
   fi
 
   # Check if were upgrading from 2.0 (the ownership of /etc/bigbluebutton/nginx/web has changed from bbb-client to bbb-web)
   if [ -f /etc/apt/sources.list.d/bigbluebutton.list ]; then
     if grep -q xenial-200 /etc/apt/sources.list.d/bigbluebutton.list; then
-      if echo $VERSION | grep -q xenial-22; then
+      if echo "$VERSION" | grep -q xenial-22; then
         if dpkg -l | grep -q bbb-client; then
           apt-get purge -y bbb-client
         fi
@@ -564,18 +564,18 @@ check_version() {
 check_host() {
   if [ -z "$PROVIDED_CERTIFICATE" ] && [ -z "$HOST" ]; then
     need_pkg dnsutils apt-transport-https net-tools
-    DIG_IP=$(dig +short $1 | grep '^[.0-9]*$' | tail -n1)
+    DIG_IP=$(dig +short "$1" | grep '^[.0-9]*$' | tail -n1)
     if [ -z "$DIG_IP" ]; then err "Unable to resolve $1 to an IP address using DNS lookup.";  fi
-    get_IP $1
+    get_IP "$1"
     if [ "$DIG_IP" != "$IP" ]; then err "DNS lookup for $1 resolved to $DIG_IP but didn't match local $IP."; fi
   fi
 }
 
 check_coturn() {
-  if ! echo $1 | grep -q ':'; then err "Option for coturn must be <hostname>:<secret>"; fi
+  if ! echo "$1" | grep -q ':'; then err "Option for coturn must be <hostname>:<secret>"; fi
 
-  COTURN_HOST=$(echo $OPTARG | cut -d':' -f1)
-  COTURN_SECRET=$(echo $OPTARG | cut -d':' -f2)
+  COTURN_HOST=$(echo "$OPTARG" | cut -d':' -f1)
+  COTURN_SECRET=$(echo "$OPTARG" | cut -d':' -f2)
 
   if [ -z "$COTURN_HOST" ];   then err "-c option must contain <hostname>"; fi
   if [ -z "$COTURN_SECRET" ]; then err "-c option must contain <secret>"; fi
@@ -587,7 +587,7 @@ check_coturn() {
     err "You must specify a new password (not the example given in the docs)."
   fi
 
-  check_host $COTURN_HOST
+  check_host "$COTURN_HOST"
 }
 
 check_apache2() {
@@ -645,10 +645,10 @@ check_nat() {
     xmlstarlet edit --inplace --update '//param[@name="ext-sip-ip"]/@value' --value "\$\${external_sip_ip}" /opt/freeswitch/conf/sip_profiles/external.xml
 
     sed -i "s/$INTERNAL_IP:/$IP:/g" /etc/bigbluebutton/nginx/sip.nginx
-    ip addr add $IP dev lo
+    ip addr add "$IP" dev lo
 
     # If dummy NIC is not in dummy-nic.service (or the file does not exist), update/create it
-    if ! grep -q $IP /lib/systemd/system/dummy-nic.service > /dev/null 2>&1; then
+    if ! grep -q "$IP" /lib/systemd/system/dummy-nic.service > /dev/null 2>&1; then
       if [ -f /lib/systemd/system/dummy-nic.service ]; then 
         DAEMON_RELOAD=true; 
       fi
@@ -812,8 +812,8 @@ install_docker() {
 
 
 install_ssl() {
-  if ! grep -q $HOST /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml; then
-    bbb-conf --setip $HOST
+  if ! grep -q "$HOST" /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml; then
+    bbb-conf --setip "$HOST"
   fi
 
   mkdir -p /etc/nginx/ssl
@@ -829,9 +829,9 @@ install_ssl() {
     openssl dhparam -dsaparam  -out /etc/nginx/ssl/dhp-4096.pem 4096
   fi
 
-  if [ ! -f /etc/letsencrypt/live/$HOST/fullchain.pem ]; then
+  if [ ! -f "/etc/letsencrypt/live/$HOST/fullchain.pem" ]; then
     rm -f /tmp/bigbluebutton.bak
-    if ! grep -q $HOST /etc/nginx/sites-available/bigbluebutton; then  # make sure we can do the challenge
+    if ! grep -q "$HOST" /etc/nginx/sites-available/bigbluebutton; then  # make sure we can do the challenge
       if [ -f /etc/nginx/sites-available/bigbluebutton ]; then
         cp /etc/nginx/sites-available/bigbluebutton /tmp/bigbluebutton.bak
       fi
@@ -856,15 +856,15 @@ HERE
     fi
 
     if [ -z "$PROVIDED_CERTIFICATE" ]; then
-      if ! certbot --email $EMAIL --agree-tos --rsa-key-size 4096 -w /var/www/bigbluebutton-default/ \
-           -d $HOST --deploy-hook "systemctl reload nginx" $LETS_ENCRYPT_OPTIONS certonly; then
+      if ! certbot --email "$EMAIL" --agree-tos --rsa-key-size 4096 -w /var/www/bigbluebutton-default/ \
+           -d "$HOST" --deploy-hook "systemctl reload nginx" "$LETS_ENCRYPT_OPTIONS" certonly; then
         systemctl restart nginx
         err "Let's Encrypt SSL request for $HOST did not succeed - exiting"
       fi
     else
-      mkdir -p /etc/letsencrypt/live/$HOST/
-      ln -s /local/certs/fullchain.pem /etc/letsencrypt/live/$HOST/fullchain.pem
-      ln -s /local/certs/privkey.pem /etc/letsencrypt/live/$HOST/privkey.pem
+      mkdir -p "/etc/letsencrypt/live/$HOST/"
+      ln -s /local/certs/fullchain.pem "/etc/letsencrypt/live/$HOST/fullchain.pem"
+      ln -s /local/certs/privkey.pem "/etc/letsencrypt/live/$HOST/privkey.pem"
     fi
   fi
 
@@ -914,7 +914,7 @@ HERE
   xmlstarlet edit --inplace --update '//param[@name="wss-binding"]/@value' --value "$IP:7443" /opt/freeswitch/conf/sip_profiles/external.xml
  
   source /etc/bigbluebutton/bigbluebutton-release
-  if [ ! -z "$(echo $BIGBLUEBUTTON_RELEASE | grep '2.2')" ] && [ "$(echo "$BIGBLUEBUTTON_RELEASE" | cut -d\. -f3)" -lt 29 ]; then
+  if [ ! -z "$(echo "$BIGBLUEBUTTON_RELEASE" | grep '2.2')" ] && [ "$(echo "$BIGBLUEBUTTON_RELEASE" | cut -d\. -f3)" -lt 29 ]; then
     sed -i "s/proxy_pass .*/proxy_pass https:\/\/$IP:7443;/g" /etc/bigbluebutton/nginx/sip.nginx
   else
     # Use nginx as proxy for WSS -> WS (see https://github.com/bigbluebutton/bigbluebutton/issues/9667)
@@ -936,7 +936,7 @@ HERE
   fi
 
   if [ -f /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml ]; then
-    yq w -i /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml public.note.url https://$HOST/pad
+    yq w -i /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml public.note.url "https://$HOST/pad"
   fi
 
   # Update Greenlight (if installed) to use SSL
@@ -965,7 +965,7 @@ HERE
       yq w -i $TARGET kurento[0].ip "$IP"
       yq w -i $TARGET freeswitch.ip "$IP"
 
-      if [ ! -z "$(echo $BIGBLUEBUTTON_RELEASE | grep '2.2')" ] && [ "$(echo "$BIGBLUEBUTTON_RELEASE" | cut -d\. -f3)" -lt 29 ]; then
+      if [ ! -z "$(echo "$BIGBLUEBUTTON_RELEASE" | grep '2.2')" ] && [ "$(echo "$BIGBLUEBUTTON_RELEASE" | cut -d\. -f3)" -lt 29 ]; then
         if [ ! -z "$INTERNAL_IP" ]; then
           yq w -i $TARGET freeswitch.sip_ip "$INTERNAL_IP"
         else
@@ -1032,13 +1032,13 @@ install_coturn() {
   need_pkg software-properties-common certbot
 
   if ! certbot certonly --standalone --non-interactive --preferred-challenges http \
-         -d $COTURN_HOST --email $EMAIL --agree-tos -n ; then
+         -d "$COTURN_HOST" --email "$EMAIL" --agree-tos -n ; then
      err "Let's Encrypt SSL request for $COTURN_HOST did not succeed - exiting"
   fi
 
   need_pkg coturn
 
-  if [ ! -z $INTERNAL_IP ]; then
+  if [ ! -z "$INTERNAL_IP" ]; then
     EXTERNAL_IP="external-ip=$IP/$INTERNAL_IP"
   fi
 
@@ -1058,7 +1058,7 @@ fingerprint
 lt-cred-mech
 use-auth-secret
 static-auth-secret=$COTURN_SECRET
-realm=$(echo $COTURN_HOST | cut -d'.' -f2-)
+realm=$(echo "$COTURN_HOST" | cut -d'.' -f2-)
 
 cert=/etc/turnserver/fullchain.pem
 pkey=/etc/turnserver/privkey.pem


### PR DESCRIPTION
SC2086: Double quote to prevent globbing and word splitting.
https://github.com/koalaman/shellcheck/wiki/SC2086