### PR TITLE
Make sure the latest version of greenlight is used

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -288,8 +288,10 @@ main() {
 
     touch /root/.rnd
     MONGODB=mongodb-org
-    install_docker		                     # needed for bbb-libreoffice-docker
-    docker pull openjdk:11-jre-buster      # fix issue 413
+    install_docker                           # needed for bbb-libreoffice-docker
+    docker pull bigbluebutton/greenlight:v2  # Make sure the current version of
+                                             # greenlight is pulled
+    docker pull openjdk:11-jre-buster        # fix issue 413
     docker tag openjdk:11-jre-buster openjdk:11-jre
     need_pkg ruby
     gem install bundler -v 2.1.4


### PR DESCRIPTION
I experienced this issue where greenlight wasn't updated when I upgraded
from 2.2 to 2.3 resulting in broken letsencrypt certificates in the
docker container.

Also would it be possible to let this PR be counted for the hacktoberfest? :P