### PR TITLE
Fix for Coturn listening and relay IP

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1050,8 +1050,8 @@ install_coturn() {
 listening-port=3478
 tls-listening-port=443
 
-listening_ip=$IP
-relay_ip=$IP
+listening-ip=$IP
+relay-ip=$IP
 $EXTERNAL_IP
 
 min-port=32769


### PR DESCRIPTION
I do not know whether this is a version subject, but in our version of Coturn the two configuration directives do not use an underscore but a dash.