### PR TITLE
Replaced 2.3 repo with 2.4 bionic-240

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -27,15 +27,15 @@
 #  Install BigBlueButton with a SSL certificate from Let's Encrypt using hostname bbb.example.com
 #  and email address info@example.com and apply a basic firewall
 #
-#    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -w -v bionic-230 -s bbb.example.com -e info@example.com 
+#    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -w -v bionic-240 -s bbb.example.com -e info@example.com 
 #
 #  Same as above but also install the API examples for testing.
 #
-#    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -w -a -v bionic-230 -s bbb.example.com -e info@example.com 
+#    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -w -a -v bionic-240 -s bbb.example.com -e info@example.com 
 #
 #  Install BigBlueButton with SSL + Greenlight
 #
-#    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -w -v bionic-230 -s bbb.example.com -e info@example.com -g
+#    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install.sh | bash -s -- -w -v bionic-240 -s bbb.example.com -e info@example.com -g
 #
 
 usage() {
@@ -51,7 +51,7 @@ USAGE:
 
 OPTIONS (install BigBlueButton):
 
-  -v <version>           Install given version of BigBlueButton (e.g. 'bionic-230') (required)
+  -v <version>           Install given version of BigBlueButton (e.g. 'bionic-240') (required)
 
   -s <hostname>          Configure server with <hostname>
   -e <email>             Email for Let's Encrypt certbot
@@ -89,9 +89,9 @@ EXAMPLES:
 
 Sample options for setup a BigBlueButton server
 
-    -v bionic-230 -s bbb.example.com -e info@example.com
-    -v bionic-230 -s bbb.example.com -e info@example.com -g
-    -v bionic-230 -s bbb.example.com -e info@example.com -g -c turn.example.com:1234324
+    -v bionic-240 -s bbb.example.com -e info@example.com
+    -v bionic-240 -s bbb.example.com -e info@example.com -g
+    -v bionic-240 -s bbb.example.com -e info@example.com -g -c turn.example.com:1234324
 
 Sample options for setup of a coturn server (on a Ubuntu 20.04)
 


### PR DESCRIPTION
Now that BBB 2.4.0 is released, we can expect 2.4 to be the recommended version in the next months.

Note that `bionic-230` is still supported - this is the repository where 2.3.x releases are pushed - 2.3.17, 2.3.18, etc