### PR TITLE
Add TLSv1.3 support

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -898,7 +898,6 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers on;
-    ssl_ecdh_curve secp521r1:secp384r1;
     ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
     
     # HSTS (comment out to enable)

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -895,9 +895,10 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/$HOST/privkey.pem;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
-    ssl_protocols TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers on;
+    ssl_ecdh_curve secp521r1:secp384r1;
     ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
     
     # HSTS (comment out to enable)


### PR DESCRIPTION
Currently, these's no support for TLSv1.3, but this TLS version is supported with the required software and OS versions.


Edit: Removed the `ssl_ecdh_curve` setting.
Also, the key exchange can be optimized by using `ssl_ecdh_curve`.

With these changes, you'll get an A+ rating on Qualys SSL Labs (100/100/100/90):
![image](https://user-images.githubusercontent.com/9428899/150319830-0d513a71-5edf-46c1-834f-7cad941038fb.png)

<details>
  <summary>Supported ciphers/handshake simulation</summary>

Also from Qualys SSL Labs
![image](https://user-images.githubusercontent.com/9428899/150320841-42dda862-1b37-4b9b-ab35-95d6f22b78be.png)

</details>
