### PR TITLE
Disable ICE-TCP in KMS, use newer config name

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -706,7 +706,7 @@ configure_HTML5() {
    sed -i 's/;stunServerPort.*/stunServerPort=19302/g'                 /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
 
    sed -i "s/[;]*externalIPv4=.*/externalIPv4=$IP/g"                   /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
-   # sed -i "s/[;]*niceAgentIceTcp=.*/niceAgentIceTcp=0/g"               /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
+   sed -i "s/[;]*iceTcp=.*/iceTcp=0/g"                                 /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
   fi
 
 


### PR DESCRIPTION
This was reverted in commit https://github.com/bigbluebutton/bbb-install/commit/a5a5045ccb8041b6c14b3cad58215008ad72fae6 for reasons unknown.

ICE-TCP does _not_ make sense in a default BBB installation and should always be disabled.