### PR TITLE
Remove ssl_prefer_server_ciphers nginx option

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -897,7 +897,6 @@ server {
     ssl_session_timeout 10m;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers on;
     ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
     
     # HSTS (comment out to enable)


### PR DESCRIPTION
This option was useful with TLS versions older than 1.2 to ensure that
browsers would not pick outdated ciphers without forward secrecy.

With the current cipher list we have configured on TLS 1.2 and newer
this is no longer a problem. Allowing the client to pick cipher is a
performance optimization, since it means that phones without AES
accelleration can choose to use the faster CHACHA20-POLY1305 mode.