### PR TITLE
[2.5]Purge node12 (if found) before installing node16

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -239,6 +239,10 @@ main() {
 
     rm -rf /etc/apt/sources.list.d/kurento.list     # Kurento 6.15 now packaged with 2.3
 
+    if [ grep -q 12 /etc/apt/sources.list.d/nodesource.list ]; then # Node 12 might be installed, previously used in BigBlueButton
+      sudo apt-get purge nodejs
+      sudo rm -r /etc/apt/sources.list.d/nodesource.list
+    fi
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
       curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
     fi


### PR DESCRIPTION
In some cases (an upgrade?) NodeJS 12 was found on the system and then NodeJS 16 was not installed (in fact, the installation was interrupted)
Removing the old installation, prior to the new one