### PR TITLE
BigBlueButton 2.5 on Ubuntu 20.04

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -486,7 +486,7 @@ check_version() {
 
 check_host() {
   if [ -z "$PROVIDED_CERTIFICATE" ] && [ -z "$HOST" ]; then
-    need_pkg dnsutils apt-transport-https net-tools
+    need_pkg dnsutils apt-transport-https
     DIG_IP=$(dig +short "$1" | grep '^[.0-9]*$' | tail -n1)
     if [ -z "$DIG_IP" ]; then err "Unable to resolve $1 to an IP address using DNS lookup.";  fi
     get_IP "$1"

--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -567,7 +567,7 @@ check_nat() {
     xmlstarlet edit --inplace --update '//param[@name="ext-rtp-ip"]/@value' --value "\$\${external_rtp_ip}" /opt/freeswitch/conf/sip_profiles/external.xml
     xmlstarlet edit --inplace --update '//param[@name="ext-sip-ip"]/@value' --value "\$\${external_sip_ip}" /opt/freeswitch/conf/sip_profiles/external.xml
 
-    sed -i "s/$INTERNAL_IP:/$IP:/g" /etc/bigbluebutton/nginx/sip.nginx
+    sed -i "s/$INTERNAL_IP:/$IP:/g" /usr/share/bigbluebutton/nginx/sip.nginx
     ip addr add "$IP" dev lo
 
     # If dummy NIC is not in dummy-nic.service (or the file does not exist), update/create it
@@ -663,9 +663,9 @@ install_greenlight(){
 
   # need_pkg bbb-webhooks
 
-  if [ ! -f /etc/bigbluebutton/nginx/greenlight.nginx ]; then
-    docker run --rm bigbluebutton/greenlight:v2 cat ./greenlight.nginx | tee /etc/bigbluebutton/nginx/greenlight.nginx
-    cat > /etc/bigbluebutton/nginx/greenlight-redirect.nginx << HERE
+  if [ ! -f /usr/share/bigbluebutton/nginx/greenlight.nginx ]; then
+    docker run --rm bigbluebutton/greenlight:v2 cat ./greenlight.nginx | tee /usr/share/bigbluebutton/nginx/greenlight.nginx
+    cat > /usr/share/bigbluebutton/nginx/greenlight-redirect.nginx << HERE
 location = / {
   return 307 /b;
 }
@@ -824,7 +824,8 @@ server {
   }
 
   # Include specific rules for record and playback
-  include /etc/bigbluebutton/nginx/*.nginx;
+  include /usr/share/bigbluebutton/nginx/*.nginx;
+  include /etc/bigbluebutton/nginx/*.nginx; # possible overrides
 }
 HERE
 
@@ -833,11 +834,11 @@ HERE
  
   source /etc/bigbluebutton/bigbluebutton-release
   if [ -n "$(echo "$BIGBLUEBUTTON_RELEASE" | grep '2.2')" ] && [ "$(echo "$BIGBLUEBUTTON_RELEASE" | cut -d\. -f3)" -lt 29 ]; then
-    sed -i "s/proxy_pass .*/proxy_pass https:\/\/$IP:7443;/g" /etc/bigbluebutton/nginx/sip.nginx
+    sed -i "s/proxy_pass .*/proxy_pass https:\/\/$IP:7443;/g" /usr/share/bigbluebutton/nginx/sip.nginx
   else
     # Use nginx as proxy for WSS -> WS (see https://github.com/bigbluebutton/bigbluebutton/issues/9667)
     yq w -i /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml public.media.sipjsHackViaWs true
-    sed -i "s/proxy_pass .*/proxy_pass http:\/\/$IP:5066;/g" /etc/bigbluebutton/nginx/sip.nginx
+    sed -i "s/proxy_pass .*/proxy_pass http:\/\/$IP:5066;/g" /usr/share/bigbluebutton/nginx/sip.nginx
     xmlstarlet edit --inplace --update '//param[@name="ws-binding"]/@value' --value "$IP:5066" /opt/freeswitch/conf/sip_profiles/external.xml
   fi
 

--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -269,8 +269,8 @@ main() {
 
     BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties            # Override file for local settings 
 
-    need_pkg openjdk-8-jre
-    update-java-alternatives -s java-1.8.0-openjdk-amd64
+    need_pkg openjdk-11-jre
+    update-java-alternatives -s java-1.11.0-openjdk-amd64
   fi
 
   apt-get update

--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -736,7 +736,6 @@ install_ssl() {
 
   if [ -z "$PROVIDED_CERTIFICATE" ]; then
     add-apt-repository universe
-    need_ppa certbot-ubuntu-certbot-xenial.list ppa:certbot/certbot 75BCA694
     apt-get update
     need_pkg certbot
   fi

--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -243,7 +243,7 @@ main() {
 
     rm -rf /etc/apt/sources.list.d/kurento.list     # Kurento 6.15 now packaged with 2.3
 
-    if [ grep -q 12 /etc/apt/sources.list.d/nodesource.list ]; then # Node 12 might be installed, previously used in BigBlueButton
+    if grep -q 12 /etc/apt/sources.list.d/nodesource.list ; then # Node 12 might be installed, previously used in BigBlueButton
       sudo apt-get purge nodejs
       sudo rm -r /etc/apt/sources.list.d/nodesource.list
     fi
@@ -736,13 +736,11 @@ install_ssl() {
 
   if [ -z "$PROVIDED_CERTIFICATE" ]; then
     add-apt-repository universe
-    #need_ppa certbot-ubuntu-certbot-xenial.list ppa:certbot/certbot 75BCA694
-    #apt-get update
-    #need_pkg certbot
-    snap install --classic certbot
+    need_ppa certbot-ubuntu-certbot-xenial.list ppa:certbot/certbot 75BCA694
+    apt-get update
+    need_pkg certbot
   fi
 
-  snap install --classic certbot
   if [ ! -f /etc/nginx/ssl/dhp-4096.pem ]; then
     openssl dhparam -dsaparam  -out /etc/nginx/ssl/dhp-4096.pem 4096
   fi
@@ -942,7 +940,6 @@ install_coturn() {
   apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
-  snap install --classic certbot
   need_pkg software-properties-common
 
   if ! certbot certonly --standalone --non-interactive --preferred-challenges http \

--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -236,7 +236,7 @@ main() {
     #need_ppa rmescandon-ubuntu-yq-bionic.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
 
     #need_ppa libreoffice-ubuntu-ppa-focal.list       ppa:libreoffice/ppa        1378B444 # Latest version of libreoffice
-    #need_ppa bigbluebutton-ubuntu-support-bionic.list ppa:bigbluebutton/support  E95B94BC # Latest version of ffmpeg
+    need_ppa bigbluebutton-ubuntu-support-bionic.list ppa:bigbluebutton/support  E95B94BC # Needed for libopusenc0
     if ! apt-key list 5AFA7A83 | grep -q -E "1024|4096"; then   # Add Kurento package
       sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
     fi


### PR DESCRIPTION
Goes together with https://github.com/bigbluebutton/bigbluebutton/pull/14600
check that pull request for more details.

Short version -- these are changes to bbb-install-2.5.sh to support BigBlueButton 2.5-alpha-5 onwards to run on Ubuntu 20.04.  Upgrades are not supported (we're in alpha stage anyway)