### PR TITLE
Restart journald to avoid error "No journal files were found"

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -323,6 +323,8 @@ main() {
     systemctl daemon-reload
   fi
 
+  systemctl restart systemd-journald
+
   if [ -n "$UFW" ]; then
     setup_ufw 
   fi


### PR DESCRIPTION
When bbb-install finishes a clean install we see

```
No journal files were found.
Failed to add filter for units: No data available
```

@ffdixon suggests including `systemctl restart systemd-journald` to resolve it
