### PR TITLE
Adjust BBB nginx config for BBB PR 14735

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -828,8 +828,7 @@ server {
   }
 
   # Include specific rules for record and playback
-  include /usr/share/bigbluebutton/nginx/*.nginx;
-  include /etc/bigbluebutton/nginx/*.nginx; # possible overrides
+  include /etc/bigbluebutton/nginx/*.nginx;
 }
 HERE
 


### PR DESCRIPTION
Don't include nginx config provided by the packages directly. Instead
include a symlink which is installed by bbb-config. Operators can remove
the symlink and install their own config file.

See https://github.com/bigbluebutton/bigbluebutton/pull/14735