### PR TITLE
No need to install build-essential

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -275,7 +275,7 @@ main() {
   apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
-  need_pkg nodejs $MONGODB apt-transport-https haveged build-essential
+  need_pkg nodejs $MONGODB apt-transport-https haveged
   need_pkg bigbluebutton
   need_pkg bbb-html5
 


### PR DESCRIPTION
suggested by @kepstin in https://github.com/bigbluebutton/bbb-install/pull/513#discussion_r857959553

I just had the chance to test an installation without `build-essential` and all seems well