### PR TITLE
Replace netstat with ss

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -372,8 +372,8 @@ need_x64() {
 
 wait_443() {
   echo "Waiting for port 443 to clear "
-  # netstat fields 4 and 6 are Local Address and State
-  while netstat -ant | awk '{print $4, $6}' | grep TIME_WAIT | grep -q ":443"; do sleep 1; echo -n '.'; done
+  # ss fields 4 and 6 are Local Address and State
+  while ss -ant | awk '{print $4, $6}' | grep TIME_WAIT | grep -q ":443"; do sleep 1; echo -n '.'; done
   echo
 }
 


### PR DESCRIPTION
Replace `netstat` with `ss` as `net-tools` are no longer present on BigBlueButton Ubuntu 20.04+ installations https://github.com/bigbluebutton/bigbluebutton/issues/14867#issuecomment-1132996564

Similar to https://github.com/bigbluebutton/bigbluebutton/pull/14660