### PR TITLE
(feat) Remove demo-server 

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -155,9 +155,6 @@ main() {
       l)
         LETS_ENCRYPT_ONLY=true
         ;;
-      g)
-        GREENLIGHT=true
-        ;;
       a)
         API_DEMOS=true
         ;;
@@ -186,6 +183,7 @@ main() {
         ;;
     esac
   done
+  GREENLIGHT=true
 
   if [ -n "$HOST" ]; then
     check_host "$HOST"
@@ -290,11 +288,6 @@ main() {
   check_LimitNOFILE
 
   configure_HTML5 
-
-  if [ -n "$API_DEMOS" ]; then
-    need_pkg bbb-demo
-    while [ ! -f /var/lib/$TOMCAT_USER/webapps/demo/bbb_api_conf.jsp ]; do sleep 1; echo -n '.'; done
-  fi
 
   if [ -n "$LINK_PATH" ]; then
     ln -s "$LINK_PATH" "/var/bigbluebutton"
@@ -764,11 +757,16 @@ server {
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
-  # BigBlueButton landing page.
-  location / {
+  # BigBlueButton asstes and static content.
+  location /assets {
     root   /var/www/bigbluebutton-default;
     index  index.html index.htm;
     expires 1m;
+  }
+
+  # BigBlueButton landing page (Greenlight).
+  location / {
+    return 307 /b
   }
 }
 HERE
@@ -818,11 +816,16 @@ server {
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
-  # BigBlueButton landing page.
-  location / {
+  # BigBlueButton asstes and static content.
+  location /assets {
     root   /var/www/bigbluebutton-default;
     index  index.html index.htm;
     expires 1m;
+  }
+
+  # BigBlueButton landing page (Greenlight).
+  location / {
+    return 307 /b
   }
 
   # Include specific rules for record and playback
@@ -851,10 +854,6 @@ HERE
 
   yq w -i /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml playback_protocol https
   chmod 644 /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml 
-
-  if [ -f /var/lib/$TOMCAT_USER/webapps/demo/bbb_api_conf.jsp ]; then
-    sed -i 's/String BigBlueButtonURL = "http:/String BigBlueButtonURL = "https:/g' /var/lib/$TOMCAT_USER/webapps/demo/bbb_api_conf.jsp
-  fi
 
   if [ -f /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml ]; then
     yq w -i /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml public.note.url "https://$HOST/pad"

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -28,10 +28,6 @@
 #
 #    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh | bash -s -- -w -v focal-260 -s bbb.example.com -e info@example.com 
 #
-#  Same as above but also install the API examples for testing.
-#
-#    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh | bash -s -- -w -a -v focal-260 -s bbb.example.com -e info@example.com 
-#
 #  Install BigBlueButton with SSL + Greenlight
 #
 #    wget -qO- https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh | bash -s -- -w -v focal-260 -s bbb.example.com -e info@example.com -g
@@ -57,7 +53,6 @@ OPTIONS (install BigBlueButton):
 
   -x                     Use Let's Encrypt certbot with manual dns challenges
 
-  -a                     Install BBB API demos
   -g                     Install Greenlight
   -c <hostname>:<secret> Configure with coturn server at <hostname> using <secret>
 
@@ -292,7 +287,7 @@ main() {
   configure_HTML5 
 
   if [ -n "$API_DEMOS" ]; then
-    echo "Warning: Installing API-Demos is not possible anymore."
+    echo "Attention: bbb-demo (API demos, '-a' option) were deprecated in BigBlueButton 2.6. Please use Greenlight or API MATE"
   fi
 
   if [ -n "$LINK_PATH" ]; then

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -758,7 +758,7 @@ server {
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
-  # BigBlueButton asstes and static content.
+  # BigBlueButton assets and static content.
   location / {
     root   /var/www/bigbluebutton-default;
     index  index.html index.htm;
@@ -812,7 +812,7 @@ server {
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
-  # BigBlueButton asstes and static content.
+  # BigBlueButton assets and static content.
   location / {
     root   /var/www/bigbluebutton-default;
     index  index.html index.htm;

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -155,6 +155,9 @@ main() {
       l)
         LETS_ENCRYPT_ONLY=true
         ;;
+      g)
+        GREENLIGHT=true
+        ;;
       a)
         API_DEMOS=true
         ;;
@@ -183,7 +186,6 @@ main() {
         ;;
     esac
   done
-  GREENLIGHT=true
 
   if [ -n "$HOST" ]; then
     check_host "$HOST"
@@ -289,6 +291,10 @@ main() {
 
   configure_HTML5 
 
+  if [ -n "$API_DEMOS" ]; then
+    echo "Warning: Installing API-Demos is not possible anymore."
+  fi
+
   if [ -n "$LINK_PATH" ]; then
     ln -s "$LINK_PATH" "/var/bigbluebutton"
   fi
@@ -301,6 +307,9 @@ main() {
 
   if [ -n "$GREENLIGHT" ]; then
     install_greenlight
+    SET_GREENLIGHT_ROOT="location / {
+      return 307 /b;
+    }"
   fi
 
   if [ -n "$COTURN" ]; then
@@ -764,10 +773,7 @@ server {
     expires 1m;
   }
 
-  # BigBlueButton landing page (Greenlight).
-  location / {
-    return 307 /b
-  }
+  $SET_GREENLIGHT_ROOT
 }
 HERE
       systemctl restart nginx
@@ -823,10 +829,7 @@ server {
     expires 1m;
   }
 
-  # BigBlueButton landing page (Greenlight).
-  location / {
-    return 307 /b
-  }
+  $SET_GREENLIGHT_ROOT
 
   # Include specific rules for record and playback
   include /usr/share/bigbluebutton/nginx/*.nginx;

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -307,9 +307,6 @@ main() {
 
   if [ -n "$GREENLIGHT" ]; then
     install_greenlight
-    SET_GREENLIGHT_ROOT="location / {
-      return 307 /b;
-    }"
   fi
 
   if [ -n "$COTURN" ]; then
@@ -767,13 +764,11 @@ server {
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
   # BigBlueButton asstes and static content.
-  location /assets {
+  location / {
     root   /var/www/bigbluebutton-default;
     index  index.html index.htm;
     expires 1m;
   }
-
-  $SET_GREENLIGHT_ROOT
 }
 HERE
       systemctl restart nginx
@@ -823,13 +818,11 @@ server {
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
   # BigBlueButton asstes and static content.
-  location /assets {
+  location / {
     root   /var/www/bigbluebutton-default;
     index  index.html index.htm;
     expires 1m;
   }
-
-  $SET_GREENLIGHT_ROOT
 
   # Include specific rules for record and playback
   include /usr/share/bigbluebutton/nginx/*.nginx;


### PR DESCRIPTION
## What does this PR do

It removes the demo-server's references from the bbb-install script and also makes Greenlight installed by default, configured to serve in the old demo-server's endpoint, the `/`.

## More

PR related to [ #15216](https://github.com/bigbluebutton/bigbluebutton/pull/15216) from bigbluebutton repository