### PR TITLE
Tweak location root to allow cert creation

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -761,7 +761,7 @@ server {
 
   # BigBlueButton assets and static content.
   location / {
-    root   /var/www/bigbluebutton-default/assets;
+    root   /var/www/bigbluebutton-default;
     index  index.html index.htm;
     expires 1m;
   }


### PR DESCRIPTION
I am partially reverting a recent change as new setup with automatic letsencrypt certificates creation kept failing. Looks like it could not utilize the simple setup we were creating on :80