### PR TITLE
Exit with error as soon as '-a' option is detected (2.6)

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -154,7 +154,7 @@ main() {
         GREENLIGHT=true
         ;;
       a)
-        API_DEMOS=true
+        err "Error: bbb-demo (API demos, '-a' option) were deprecated in BigBlueButton 2.6. Please use Greenlight or API MATE"
         ;;
       m)
         LINK_PATH=$OPTARG
@@ -286,10 +286,6 @@ main() {
   check_LimitNOFILE
 
   configure_HTML5 
-
-  if [ -n "$API_DEMOS" ]; then
-    err "Attention: bbb-demo (API demos, '-a' option) were deprecated in BigBlueButton 2.6. Please use Greenlight or API MATE"
-  fi
 
   if [ -n "$LINK_PATH" ]; then
     ln -s "$LINK_PATH" "/var/bigbluebutton"


### PR DESCRIPTION
Exit with error as soon as '-a' option is detected, rather than starting an install and then exiting with an error, which will end up with a broken install.

I also changed the message from "Attention" to "Error", to make it clearer.