### PR TITLE
feat: implemented -j to skip min server requirements check

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -70,6 +70,9 @@ OPTIONS (install BigBlueButton):
   -d                     Skip SSL certificates request (use provided certificates from mounted volume) in /local/certs/
   -w                     Install UFW firewall (recommended)
 
+  -j                     Allows the installation of BigBlueButton to proceed even if not all requirements [for production use] are met.
+                         Note that not all requirements can be ignored. This is useful in development / testing / ci scenarios.
+
   -h                     Print help
 
 OPTIONS (install coturn only):
@@ -112,7 +115,7 @@ main() {
 
   need_x64
 
-  while builtin getopts "hs:r:c:v:e:p:m:lxgadw" opt "${@}"; do
+  while builtin getopts "hs:r:c:v:e:p:m:lxgadwj" opt "${@}"; do
 
     case $opt in
       h)
@@ -176,6 +179,9 @@ main() {
         UFW=true
         ;;
 
+      j)
+        SKIP_MIN_SERVER_REQUIREMENTS_CHECK=true
+        ;;
       :)
         err "Missing option argument for -$OPTARG"
         exit 1
@@ -219,8 +225,11 @@ main() {
     check_ubuntu 20.04
     TOMCAT_USER=tomcat9
   fi
-  check_mem
-  check_cpus
+
+  if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
+    check_mem
+    check_cpus
+  fi
 
   need_pkg software-properties-common  # needed for add-apt-repository
   sudo add-apt-repository universe

--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -225,11 +225,8 @@ main() {
     check_ubuntu 20.04
     TOMCAT_USER=tomcat9
   fi
-
-  if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
-    check_mem
-    check_cpus
-  fi
+  check_mem
+  check_cpus
 
   need_pkg software-properties-common  # needed for add-apt-repository
   sudo add-apt-repository universe
@@ -366,13 +363,19 @@ check_root() {
 
 check_mem() {
   if awk '$1~/MemTotal/ {exit !($2<3940000)}' /proc/meminfo; then
-    err "Your server needs to have (at least) 4G of memory."
+    echo "Your server needs to have (at least) 4G of memory."
+    if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
+      exit 1
+    fi
   fi
 }
 
 check_cpus() {
   if [ "$(nproc --all)" -lt 4 ]; then
-    err "Your server needs to have (at least) 4 CPUs (8 recommended for production)."
+    echo "Your server needs to have (at least) 4 CPUs (8 recommended for production)."
+    if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
+      exit 1
+    fi
   fi
 }
 

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -64,6 +64,9 @@ OPTIONS (install BigBlueButton):
   -d                     Skip SSL certificates request (use provided certificates from mounted volume) in /local/certs/
   -w                     Install UFW firewall (recommended)
 
+  -j                     Allows the installation of BigBlueButton to proceed even if not all requirements [for production use] are met.
+                         Note that not all requirements can be ignored. This is useful in development / testing / ci scenarios.
+
   -h                     Print help
 
 OPTIONS (install coturn only):
@@ -106,7 +109,7 @@ main() {
 
   need_x64
 
-  while builtin getopts "hs:r:c:v:e:p:m:lxgadw" opt "${@}"; do
+  while builtin getopts "hs:r:c:v:e:p:m:lxgadwj" opt "${@}"; do
 
     case $opt in
       h)
@@ -169,6 +172,9 @@ main() {
         fi
         UFW=true
         ;;
+      j)
+        SKIP_MIN_SERVER_REQUIREMENTS_CHECK=true
+        ;;
 
       :)
         err "Missing option argument for -$OPTARG"
@@ -213,8 +219,11 @@ main() {
     check_ubuntu 20.04
     TOMCAT_USER=tomcat9
   fi
-  check_mem
-  check_cpus
+
+  if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
+    check_mem
+    check_cpus
+  fi
 
   need_pkg software-properties-common  # needed for add-apt-repository
   sudo add-apt-repository universe

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -219,11 +219,8 @@ main() {
     check_ubuntu 20.04
     TOMCAT_USER=tomcat9
   fi
-
-  if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
-    check_mem
-    check_cpus
-  fi
+  check_mem
+  check_cpus
 
   need_pkg software-properties-common  # needed for add-apt-repository
   sudo add-apt-repository universe
@@ -355,13 +352,19 @@ check_root() {
 
 check_mem() {
   if awk '$1~/MemTotal/ {exit !($2<3940000)}' /proc/meminfo; then
-    err "Your server needs to have (at least) 4G of memory."
+    echo "Your server needs to have (at least) 4G of memory."
+    if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
+      exit 1
+    fi
   fi
 }
 
 check_cpus() {
   if [ "$(nproc --all)" -lt 4 ]; then
-    err "Your server needs to have (at least) 4 CPUs (8 recommended for production)."
+    echo "Your server needs to have (at least) 4 CPUs (8 recommended for production)."
+    if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
+      exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION
Implements a new passed argument `-j` to skip minimum server requirements check

Follow up to https://github.com/bigbluebutton/bbb-install/commit/09c16f9bdff3408e342af1e5c6bf378d10076ba8
Closes https://github.com/bigbluebutton/bbb-install/issues/547

**Note1:** I wanted to implement this as `--skip-min-server-requirements-check` but looked like I'd have to jump through a bunch of hoops, so I opted to keep the existing one letter pattern even if it's not super descriptive. See https://stackoverflow.com/a/30026641 The long options could be implemented in one pass when https://github.com/bigbluebutton/bbb-install/issues/527 is addressed. Ideally sorting alphabetically at the same time too...

**Note2:** Initially I only wrapped the checks as follows:

```
  if [ "$SKIP_MIN_SERVER_REQUIREMENTS_CHECK" != true ]; then
    check_mem
    check_cpus
  fi
```
But then decided that it is still worth it to echo the warning. Just to not abort the installation.

**Note3:** Not all requirements are flexible enough to be skipped. For example x64 or OS specific ones -- so the naming/description of this new parameter is a bit misleading