### PR TITLE
feat: implemented -i to skip checking whether Apache webserver is installed

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -73,6 +73,8 @@ OPTIONS (install BigBlueButton):
   -j                     Allows the installation of BigBlueButton to proceed even if not all requirements [for production use] are met.
                          Note that not all requirements can be ignored. This is useful in development / testing / ci scenarios.
 
+  -i                     Allows the installation of BigBlueButton to proceed even if Apache webserver is installed.
+
   -h                     Print help
 
 OPTIONS (install coturn only):
@@ -115,7 +117,7 @@ main() {
 
   need_x64
 
-  while builtin getopts "hs:r:c:v:e:p:m:lxgadwj" opt "${@}"; do
+  while builtin getopts "hs:r:c:v:e:p:m:lxgadwji" opt "${@}"; do
 
     case $opt in
       h)
@@ -178,9 +180,11 @@ main() {
         fi
         UFW=true
         ;;
-
       j)
         SKIP_MIN_SERVER_REQUIREMENTS_CHECK=true
+        ;;
+      i)
+        SKIP_APACHE_INSTALLED_CHECK=true
         ;;
       :)
         err "Missing option argument for -$OPTARG"
@@ -202,7 +206,9 @@ main() {
     check_version "$VERSION"
   fi
 
-  check_apache2
+  if ["$SKIP_APACHE_INSTALLED_CHECK" != true]; then
+    check_apache2
+  fi
 
   # Check if we're installing coturn (need an e-mail address for Let's Encrypt)
   if [ -z "$VERSION" ] && [ -n "$COTURN" ]; then
@@ -543,7 +549,12 @@ check_coturn() {
 }
 
 check_apache2() {
-  if dpkg -l | grep -q apache2-bin; then err "You must uninstall the Apache2 server first"; fi
+  if dpkg -l | grep -q apache2-bin; then 
+    echo "You must uninstall the Apache2 server first"; 
+    if ["$SKIP_APACHE_INSTALLED_CHECK" != true];then
+      exit 1
+    fi
+  fi
 }
 
 # If running under LXC, then modify the FreeSWITCH systemctl service so it does not use realtime scheduler

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -67,7 +67,7 @@ OPTIONS (install BigBlueButton):
   -j                     Allows the installation of BigBlueButton to proceed even if not all requirements [for production use] are met.
                          Note that not all requirements can be ignored. This is useful in development / testing / ci scenarios.
 
-  -a                     Allows the installation of BigBlueButton to proceed even if Apache webserver is installed.
+  -i                     Allows the installation of BigBlueButton to proceed even if Apache webserver is installed.
 
   -h                     Print help
 

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -67,6 +67,8 @@ OPTIONS (install BigBlueButton):
   -j                     Allows the installation of BigBlueButton to proceed even if not all requirements [for production use] are met.
                          Note that not all requirements can be ignored. This is useful in development / testing / ci scenarios.
 
+  -a                     Allows the installation of BigBlueButton to proceed even if Apache webserver is installed.
+
   -h                     Print help
 
 OPTIONS (install coturn only):
@@ -109,7 +111,7 @@ main() {
 
   need_x64
 
-  while builtin getopts "hs:r:c:v:e:p:m:lxgadwj" opt "${@}"; do
+  while builtin getopts "hs:r:c:v:e:p:m:lxgadwji" opt "${@}"; do
 
     case $opt in
       h)
@@ -175,6 +177,9 @@ main() {
       j)
         SKIP_MIN_SERVER_REQUIREMENTS_CHECK=true
         ;;
+      i)
+        SKIP_APACHE_INSTALLED_CHECK=true
+        ;;
 
       :)
         err "Missing option argument for -$OPTARG"
@@ -196,7 +201,9 @@ main() {
     check_version "$VERSION"
   fi
 
-  check_apache2
+  if [ "$SKIP_APACHE_INSTALLED_CHECK" != true ]; then
+    check_apache2
+  fi
 
   # Check if we're installing coturn (need an e-mail address for Let's Encrypt)
   if [ -z "$VERSION" ] && [ -n "$COTURN" ]; then
@@ -532,7 +539,12 @@ check_coturn() {
 }
 
 check_apache2() {
-  if dpkg -l | grep -q apache2-bin; then err "You must uninstall the Apache2 server first"; fi
+  if dpkg -l | grep -q apache2-bin; then 
+    echo "You must uninstall the Apache2 server first";
+    if [ "$SKIP_APACHE_INSTALLED_CHECK" != true ]; then
+      exit 1;
+   fi 
+  fi
 }
 
 # If running under LXC, then modify the FreeSWITCH systemctl service so it does not use realtime scheduler

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -114,7 +114,7 @@ main() {
 
   need_x64
 
-  while builtin getopts "hs:r:c:v:e:p:m:lxgadwi" opt "${@}"; do
+  while builtin getopts "hs:r:c:v:e:p:m:lxgadw" opt "${@}"; do
 
     case $opt in
       h)
@@ -177,10 +177,6 @@ main() {
         fi
         UFW=true
         ;;
-      d)
-        SKIP_APACHE_INSTALLED_CHECK=true
-        ;;
-
 
       :)
         err "Missing option argument for -$OPTARG"
@@ -202,9 +198,7 @@ main() {
     check_version "$VERSION"
   fi
 
-  if ["$SKIP_APACHE_INSTALLED_CHECK" != true ]; then
-    check_apache2
-  fi
+  check_apache2
 
   # Check if we're installing coturn (need an e-mail address for Let's Encrypt)
   if [ -z "$VERSION" ] && [ -n "$COTURN" ]; then
@@ -605,12 +599,7 @@ check_coturn() {
 }
 
 check_apache2() {
-  if dpkg -l | grep -q apache2-bin; then 
-    echo "You must uninstall the Apache2 server first"; 
-    if ["$SKIP_APACHE_INSTALLED_CHECK" != true ]; then
-       exit 1
-    fi
-  fi
+  if dpkg -l | grep -q apache2-bin; then err "You must uninstall the Apache2 server first"; fi
 }
 
 # If running under LXC, then modify the FreeSWITCH systemctl service so it does not use realtime scheduler

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -70,8 +70,6 @@ OPTIONS (install BigBlueButton):
   -d                     Skip SSL certificates request (use provided certificates from mounted volume) in /local/certs/
   -w                     Install UFW firewall (recommended)
 
-  -i                     Allows the installation of BigBlueButton to proceed even if Apache webserver is installed.
-
   -h                     Print help
 
 OPTIONS (install coturn only):


### PR DESCRIPTION
do not stop execution if -i option is set and Apache is installed, just warn the user.
Apache can be installed and harmlessly listening on different ports (i.e. being server by nginx as a reverse proxy)