### PR TITLE
refactor: Removes workaround to pull docker image openjdk:11-jre-buster

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -275,8 +275,6 @@ main() {
     touch /root/.rnd
     MONGODB=mongodb-org
     install_docker		                     # needed for bbb-libreoffice-docker
-    docker pull openjdk:11-jre-buster      # fix issue 413
-    docker tag openjdk:11-jre-buster openjdk:11-jre
     need_pkg ruby
 
     BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties            # Override file for local settings 

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -270,8 +270,6 @@ main() {
     touch /root/.rnd
     MONGODB=mongodb-org
     install_docker		                     # needed for bbb-libreoffice-docker
-    docker pull openjdk:11-jre-buster      # fix issue 413
-    docker tag openjdk:11-jre-buster openjdk:11-jre
     need_pkg ruby
 
     BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties            # Override file for local settings 


### PR DESCRIPTION
As explained in https://github.com/bigbluebutton/bbb-install/issues/413#issuecomment-906471106
This two lines was a workaround to force `bbb-libreoffice-docker` to use the docker image `openjdk:11-jre-buster` instead of `openjdk:11-jre` (without Debian version specified).

It is not necessary anymore, once now the Dockerfile already specifies the debian version: `openjdk:17-slim-bullseye`.
And the `backports` is using the exact same version of the image, so that problem will not happen anymore!
https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bbb-libreoffice/docker/Dockerfile
![image](https://user-images.githubusercontent.com/5660191/186478796-e64ccbed-0373-4105-9586-9c46071fda5b.png)

