### PR TITLE
(backport) refactor: Removes workaround to pull docker image openjdk:11-jre-buster

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -278,9 +278,6 @@ main() {
     MONGODB=mongodb-org
     install_docker		                     # needed for bbb-libreoffice-docker
 
-    docker pull openjdk:11-jre-buster      # fix issue 413
-    docker tag openjdk:11-jre-buster openjdk:11-jre
-
     need_pkg ruby
 
     BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties            # Override file for local settings 


### PR DESCRIPTION
Backport of #557.

It was requested to remove these lines once this PR was merged!
https://github.com/bigbluebutton/bigbluebutton/pull/15613