### PR TITLE
Fix greenlight redirect to avoid extra hop

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -696,7 +696,7 @@ install_greenlight(){
     docker run --rm bigbluebutton/greenlight:v2 cat ./greenlight.nginx | tee /usr/share/bigbluebutton/nginx/greenlight.nginx
     cat > /usr/share/bigbluebutton/nginx/greenlight-redirect.nginx << HERE
 location = / {
-  return 307 /b;
+  return 307 /b/;
 }
 HERE
     systemctl restart nginx


### PR DESCRIPTION
`greenlight-redirect.nginx` was redirecting `/` to `/b`, but then it was redirecting to `/b/`, causing an extra hop

Before this fix:
![image](https://user-images.githubusercontent.com/2075267/200920282-eb1ade83-70da-4c62-8bcd-72ffe5df431b.png)

After this fix:
![image](https://user-images.githubusercontent.com/2075267/200920429-1def52f7-87e3-475b-b4dc-5604ff962876.png)
