### PR TITLE
Allow proxy port numbers to be set

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -64,7 +64,7 @@ OPTIONS (install BigBlueButton):
 
   -m <link_path>         Create a Symbolic link from /var/bigbluebutton to <link_path> 
 
-  -p <host>              Use apt-get proxy at <host>
+  -p <host>[:<port>]     Use apt-get proxy at <host> (default port 3142)
   -r <host>              Use alternative apt repository (such as packages-eu.bigbluebutton.org)
 
   -d                     Skip SSL certificates request (use provided certificates from mounted volume) in /local/certs/
@@ -156,7 +156,11 @@ main() {
       p)
         PROXY=$OPTARG
         if [ -n "$PROXY" ]; then
-          echo "Acquire::http::Proxy \"http://$PROXY:3142\";"  > /etc/apt/apt.conf.d/01proxy
+          if [[ "$PROXY" =~ : ]]; then
+            echo "Acquire::http::Proxy \"http://$PROXY\";"  > /etc/apt/apt.conf.d/01proxy
+          else
+            echo "Acquire::http::Proxy \"http://$PROXY:3142\";"  > /etc/apt/apt.conf.d/01proxy
+          fi
         fi
         ;;
 

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -58,7 +58,7 @@ OPTIONS (install BigBlueButton):
 
   -m <link_path>         Create a Symbolic link from /var/bigbluebutton to <link_path> 
 
-  -p <host>              Use apt-get proxy at <host>
+  -p <host>[:<port>]     Use apt-get proxy at <host> (default port 3142)
   -r <host>              Use alternative apt repository (such as packages-eu.bigbluebutton.org)
 
   -d                     Skip SSL certificates request (use provided certificates from mounted volume) in /local/certs/
@@ -150,7 +150,11 @@ main() {
       p)
         PROXY=$OPTARG
         if [ -n "$PROXY" ]; then
-          echo "Acquire::http::Proxy \"http://$PROXY:3142\";"  > /etc/apt/apt.conf.d/01proxy
+          if [[ "$PROXY" =~ : ]]; then
+            echo "Acquire::http::Proxy \"http://$PROXY\";"  > /etc/apt/apt.conf.d/01proxy
+          else
+            echo "Acquire::http::Proxy \"http://$PROXY:3142\";"  > /etc/apt/apt.conf.d/01proxy
+          fi
         fi
         ;;
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -64,7 +64,7 @@ OPTIONS (install BigBlueButton):
 
   -m <link_path>         Create a Symbolic link from /var/bigbluebutton to <link_path> 
 
-  -p <host>              Use apt-get proxy at <host>
+  -p <host>[:<port>]     Use apt-get proxy at <host> (default port 3142)
   -r <host>              Use alternative apt repository (such as packages-eu.bigbluebutton.org)
 
   -d                     Skip SSL certificates request (use provided certificates from mounted volume) in /local/certs/
@@ -149,7 +149,11 @@ main() {
       p)
         PROXY=$OPTARG
         if [ -n "$PROXY" ]; then
-          echo "Acquire::http::Proxy \"http://$PROXY:3142\";"  > /etc/apt/apt.conf.d/01proxy
+          if [[ "$PROXY" =~ : ]]; then
+            echo "Acquire::http::Proxy \"http://$PROXY\";"  > /etc/apt/apt.conf.d/01proxy
+          else
+            echo "Acquire::http::Proxy \"http://$PROXY:3142\";"  > /etc/apt/apt.conf.d/01proxy
+          fi
         fi
         ;;
 


### PR DESCRIPTION
Allow port numbers to be optionally specified to the bbb-install proxy (-p) switch

Closes issue #572 
