### PR TITLE
Always install a local TURN server and share port 443

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -307,7 +307,7 @@ main() {
     configure_coturn
   else
     install_coturn
-    instal_haproxy
+    install_haproxy
   fi
 
   apt-get auto-remove -y

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -721,11 +721,11 @@ backend turn
 
 backend nginx
   mode tcp
-  server localhost 127.0.0.1:81
+  server localhost 127.0.0.1:81 send-proxy check
 
 backend nginx-http2
   mode tcp
-  server localhost 127.0.0.1:82
+  server localhost 127.0.0.1:82 send-proxy check
 END
   chown root:haproxy "$HAPROXY_CFG"
   chmod 640 "$HAPROXY_CFG"
@@ -917,6 +917,9 @@ server {
   return 301 https://\$server_name\$request_uri; #redirect HTTP to HTTPS
 
 }
+set_real_ip_from 127.0.0.1;
+real_ip_header proxy_protocol;
+real_ip_recursive on;
 server {
   # this double listenting is intended. We terminate SSL on haproxy. HTTP2 is a
   # binary protocol. haproxy has to decide which protocol is spoken. This is
@@ -925,9 +928,9 @@ server {
   # Depending on the ALPN value traffic is redirected to either port 82 (HTTP2,
   # ALPN value h2) or 81 (HTTP 1.0 or HTTP 1.1, ALPN value http/1.1 or no value)
 
-  listen 127.0.0.1:82 http2;
+  listen 127.0.0.1:82 http2 proxy_protocol;
   listen [::1]:82 http2;
-  listen 127.0.0.1:81;
+  listen 127.0.0.1:81 proxy_protocol;
   listen [::1]:81;
   server_name $HOST;
 

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -696,7 +696,7 @@ defaults
 
 
 frontend nginx_or_turn
-  bind *:443 ssl crt /etc/haproxy/certbundle.pem ssl-min-ver TLSv1.2 alpn h2,http/1.1
+  bind *:443 ssl crt /etc/haproxy/certbundle.pem ssl-min-ver TLSv1.2 alpn h2,http/1.1,stun.turn
   mode tcp
   option tcplog
   tcp-request content capture req.payload(0,1) len 1
@@ -711,6 +711,7 @@ frontend nginx_or_turn
   # value traffic is sent to either port 81 or coturn.
   use_backend nginx-http2 if { ssl_fc_alpn h2 }
   use_backend nginx if { ssl_fc_alpn http/1.1 }
+  use_backend turn if { ssl_fc_alpn stun.turn }
   use_backend %[capture.req.hdr(0),map_str(/etc/haproxy/protocolmap,turn)]
   default_backend turn
 

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -778,10 +778,10 @@ install_greenlight(){
 
   # need_pkg bbb-webhooks
 
-  if [ ! -f /usr/share/bigbluebutton/nginx/greenlight.nginx ]; then
-    docker run --rm bigbluebutton/greenlight:v2 cat ./greenlight.nginx | tee /usr/share/bigbluebutton/nginx/greenlight.nginx
-    sed -i '/X-Forwarded-Proto/s/$scheme/"https"/' /usr/share/bigbluebutton/nginx/greenlight.nginx
-    cat > /usr/share/bigbluebutton/nginx/greenlight-redirect.nginx << HERE
+  if [ ! -f /etc/bigbluebutton/nginx/greenlight.nginx ]; then
+    docker run --rm bigbluebutton/greenlight:v2 cat ./greenlight.nginx | tee /etc/bigbluebutton/nginx//greenlight.nginx
+    sed -i '/X-Forwarded-Proto/s/$scheme/"https"/' /etc/bigbluebutton/nginx/greenlight.nginx
+    cat > /etc/bigbluebutton/nginx/greenlight-redirect.nginx << HERE
 location = / {
   return 307 https://\$server_name/b/;
 }

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -1027,6 +1027,11 @@ configure_coturn() {
 
     <bean id="turn0" class="org.bigbluebutton.web.services.turn.TurnServer">
         <constructor-arg index="0" value="$COTURN_SECRET"/>
+        <constructor-arg index="1" value="turn:$HOST:3478"/>
+        <constructor-arg index="2" value="86400"/>
+    </bean>
+    <bean id="turn1" class="org.bigbluebutton.web.services.turn.TurnServer">
+        <constructor-arg index="0" value="$COTURN_SECRET"/>
         <constructor-arg index="1" value="turns:$HOST:443?transport=tcp"/>
         <constructor-arg index="2" value="86400"/>
     </bean>
@@ -1040,6 +1045,7 @@ configure_coturn() {
         <property name="turnServers">
             <set>
                 <ref bean="turn0"/>
+                <ref bean="turn1"/>
             </set>
         </property>
     </bean>
@@ -1097,6 +1103,8 @@ denied-peer-ip=::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 allowed-peer-ip=$IP
 
 HERE
+    chown root:turnserver /etc/turnserver.conf
+    chmod 640 /etc/turnserver.conf
   else
     # fetch secret for later setting up in BBB turn config
     COTURN_SECRET="$(grep static-auth-secret= /etc/turnserver.conf |cut -d = -f 2-)"

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -738,6 +738,7 @@ mv /etc/haproxy/certbundle.pem.new /etc/haproxy/certbundle.pem
 systemctl reload haproxy
 HERE
   chmod 0755 /etc/letsencrypt/renewal-hooks/deploy/haproxy
+  /etc/letsencrypt/renewal-hooks/deploy/haproxy
 }
 
 install_greenlight(){

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -293,9 +293,6 @@ main() {
     ln -s "$LINK_PATH" "/var/bigbluebutton"
   fi
 
-  install_coturn
-  install_haproxy
-
   if [ -n "$PROVIDED_CERTIFICATE" ] ; then
     install_ssl
   elif [ -n "$HOST" ] && [ -n "$EMAIL" ] ; then
@@ -308,6 +305,9 @@ main() {
 
   if [ -n "$COTURN" ]; then
     configure_coturn
+  else
+    install_coturn
+    instal_haproxy
   fi
 
   apt-get auto-remove -y


### PR DESCRIPTION
This patch changes the current BBB 2.6 setup in the following way:

* install coturn on all machines
* install haproxy and let it serve port 443
* configure nginx to use port 127.0.0.1:81 without encryption
* configure BBB to use the local coturn using the `turns` protocol

haproxy will terminate the TLS connection and use the first byte to decide if the traffic will go to nginx or coturn.