### PR TITLE
Ensure BBB is ready to run after a NAT install

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -642,6 +642,7 @@ HERE
         systemctl start dummy-nic
       fi
     fi
+    systemctl restart freeswitch
   fi
 }
 

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -631,6 +631,7 @@ HERE
         systemctl start dummy-nic
       fi
     fi
+    systemctl restart freeswitch
   fi
 }
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -684,6 +684,7 @@ HERE
         systemctl start dummy-nic
       fi
     fi
+    systemctl restart freeswitch
   fi
 }
 


### PR DESCRIPTION
Make check_nat() restart FreeSWITCH after changing some of its configuration files,
otherwise FreeSWITCH won't be in a usable state after the install finishes.

Instead, we'll get error messages like this at the end of the install (courtesy of `bbb-conf --check`):

```
# bbb-webrtc-sfu will try to connect to 128.8.8.5 but FreeSWITCH is listening on 192.168.1.2 for port 5066
```

The problem is caused by the install script modifying the FreeSWITCH configuration after FS is already installed and running, but not restarting FS.

A simple `bbb-conf --restart` currently fixes the problem, but it's better to leave the system in a usable state at the end of the install script.