### PR TITLE
Fix TURN server configuration for TURN servers behind NAT gateways

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -1013,8 +1013,8 @@ install_coturn() {
 listening-port=3478
 tls-listening-port=443
 
-listening-ip=$IP
-relay-ip=$IP
+listening-ip=${INTERNAL_IP:-$IP}
+relay-ip=${INTERNAL_IP:-$IP}
 $EXTERNAL_IP
 
 min-port=32769

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -1002,8 +1002,8 @@ install_coturn() {
 listening-port=3478
 tls-listening-port=443
 
-listening-ip=$IP
-relay-ip=$IP
+listening-ip=${INTERNAL_IP:-$IP}
+relay-ip=${INTERNAL_IP:-$IP}
 $EXTERNAL_IP
 
 min-port=32769

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1053,8 +1053,8 @@ install_coturn() {
 listening-port=3478
 tls-listening-port=443
 
-listening-ip=$IP
-relay-ip=$IP
+listening-ip=${INTERNAL_IP:-$IP}
+relay-ip=${INTERNAL_IP:-$IP}
 $EXTERNAL_IP
 
 min-port=32769


### PR DESCRIPTION
Commit 1b19b0 (Updated for installing coturn on 20.04 - Jan 17 2021) added coturn configuration options (listening-ip, relay-ip, external-ip) that aren't properly set if the TURN server is behind a NAT gateway.

In the NAT case, both listening-ip (the address the TURN server binds to) and relay-ip (the address the TURN server transmits on) should be the private IP address.

If listening-ip and relay-ip are improperly set to the external IP address, then we get error messages (like those reported on Issue #577) that the TURN server can't bind to the public IP address.

Fixes and closes Issue #577.