### PR TITLE
Replace "need_pkg certbot" for TURN server

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -996,7 +996,7 @@ install_coturn() {
   apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
-  need_pkg software-properties-common
+  need_pkg software-properties-common certbot
 
   if ! certbot certonly --standalone --non-interactive --preferred-challenges http \
          -d "$COTURN_HOST" --email "$EMAIL" --agree-tos -n ; then

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -985,7 +985,7 @@ install_coturn() {
   apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
-  need_pkg software-properties-common
+  need_pkg software-properties-common certbot
 
   if ! certbot certonly --standalone --non-interactive --preferred-challenges http \
          -d "$COTURN_HOST" --email "$EMAIL" --agree-tos -n ; then


### PR DESCRIPTION
Commit 8233f5b8 (Mar 14 2022) switched to the snap version of certbot, and then commit aab34f1 (Mar 15 2022; Drop snap certbot) switched back, but the reverting commit only replaced the "need_pkg certbot" on the main BigBlueButton system; that two-commit sequence dropped the "need_pkg certbot" for TURN servers.

This PR replaces the dropped "need_pkg certbot" in the `bbb-install-2.5.sh` and `bbb-install-2.6.sh` scripts (`bbb-install.sh` wasn't affected)