### PR TITLE
remove obsolete shared notes settings

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -990,10 +990,6 @@ HERE
   yq w -i /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml playback_protocol https
   chmod 644 /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml 
 
-  if [ -f /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml ]; then
-    yq w -i /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml public.note.url "https://$HOST/pad"
-  fi
-
   # Update Greenlight (if installed) to use SSL
   if [ -f ~/greenlight/.env ]; then
     if ! grep ^BIGBLUEBUTTON_ENDPOINT ~/greenlight/.env | grep -q https; then


### PR DESCRIPTION
remove obsolete shared notes settings
the correct settings is set by bbb-conf 
https://github.com/bigbluebutton/bigbluebutton/blob/0c951e7f4b64dab12a696ccec79edede8cde04b6/bigbluebutton-config/bin/bbb-conf#L1669