### PR TITLE
Fix shell redirection that was sending output to a file named "2"

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -271,7 +271,7 @@ main() {
     update-java-alternatives -s java-1.11.0-openjdk-amd64
 
     # Remove old bbb-demo if installed from a previous 2.5 setup
-    if dpkg -s bbb-demo > /dev/null &>2; then
+    if dpkg -s bbb-demo > /dev/null 2>&1; then
       apt purge -y bbb-demo tomcat9
       rm -rf /var/lib/tomcat9
     fi


### PR DESCRIPTION
See https://unix.stackexchange.com/a/443826/37949 for an explanation of this confusing syntax and the difference between `&>2` and `>&2`.

`> /dev/null 2>&1` is what we use elsewhere in the install script to send both stdout and stderr to /dev/null, and that's what this PR does for the problematic line.