### PR TITLE
Adjust path for default.pdf #540

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -1013,7 +1013,7 @@ server {
 
   # BigBlueButton landing page.
   location / {
-    root   /var/www/bigbluebutton-default;
+    root   /var/www/bigbluebutton-default/assets;
     index  index.html index.htm;
     expires 1m;
   }


### PR DESCRIPTION
Reapplies #540 for the section of nginx configs introduced via https://github.com/bigbluebutton/bbb-install/commit/583f868a397a8310b2fc8f9f058d2bd3ce64b51d

Without this change, new installations won't be able to load `default.pdf`

```Feb 01 15:19:20 droplet-6872 java[66093]: 2023-02-01T15:19:20.744Z ERROR o.b.p.PresentationUrlDownloadService - Invalid HTTP response=[404] for url=[https://droplet-6872.meetbbb.com/default.pdf] with meeting[1bd639df3146a019707c1e194e82236d978f3874-1675264760118]
Feb 01 15:19:20 droplet-6872 java[66093]: 2023-02-01T15:19:20.748Z ERROR o.b.web.controllers.ApiController - Failed to download presentation=[https://droplet-6872.meetbbb.com/default.pdf], meeting=[1bd639df3146a019707c1e194e82236d978f3874-1675264760118], fileName=[]
Feb 01 15:19:20 droplet-6872 java[66093]: 2023-02-01T15:19:20.771Z ERROR o.b.presentation.SupportedFileTypes - Error while executing detectMimeType: Presentation is null
Feb 01 15:19:20 droplet-6872 java[66093]: 2023-02-01T15:19:20.777Z ERROR o.b.web.controllers.ApiController - Document [https://droplet-6872.meetbbb.com/default.pdf] sent is not supported as a presentation
```