### PR TITLE
Added "https://" to the Ubuntu Keyserver URL

### DIFF
--- a/bbb-install-2.5.sh
+++ b/bbb-install-2.5.sh
@@ -257,7 +257,7 @@ main() {
     #need_ppa libreoffice-ubuntu-ppa-focal.list       ppa:libreoffice/ppa        1378B444 # Latest version of libreoffice
     need_ppa bigbluebutton-ubuntu-support-focal.list ppa:bigbluebutton/support  E95B94BC # Needed for libopusenc0
     if ! apt-key list 5AFA7A83 | grep -q -E "1024|4096"; then   # Add Kurento package
-      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
+      sudo apt-key adv --keyserver https://keyserver.ubuntu.com --recv-keys 5AFA7A83
     fi
 
     rm -rf /etc/apt/sources.list.d/kurento.list     # Kurento 6.15 now packaged with 2.3


### PR DESCRIPTION
In my environment, a proxy route is required, so you set the variables for http_proxy and https_proxy but it isnt used if the URL does not contain the "keyword" and so the key-request runs into timeout.

If this is not sufficient, 

for me,
https://unix.stackexchange.com/questions/361213/unable-to-add-gpg-key-with-apt-key-behind-a-proxy
solved the issue.
That means we have to place

`--keyserver-options http-proxy=http://ADDRESS:PORT/`
AND/OR
`--keyserver-options https-proxy=http://ADDRESS:PORT/`

in the keyserver query,
but only if a proxy is given to the script-run by the option "-p".


This is my first ever message so please let me know if I forgot required information.

Regards :)