### PR TITLE
focal-260: Added support for Greenlight relative URL root configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,44 +113,78 @@ You can get help by passing the `-h` option.
 
 ~~~
 Script for installing a BigBlueButton 2.6 server in under 30 minutes. It also supports upgrading a BigBlueButton server to version 2.6 (from version 2.5.0+ or an earlier 2.6.x version)
+
 This script also supports installation of a coturn (TURN) server on a separate server.
+
 USAGE:
     wget -qO- https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh | bash -s -- [OPTIONS]
+
 OPTIONS (install BigBlueButton):
+
   -v <version>           Install given version of BigBlueButton (e.g. 'focal-260') (required)
+
   -s <hostname>          Configure server with <hostname>
   -e <email>             Email for Let's Encrypt certbot
+
   -x                     Use Let's Encrypt certbot with manual dns challenges
+
   -g                     Install Greenlight version 3
   -k                     Install Keycloak version 20
+
   -t <key>:<secret>      Install BigBlueButton LTI framework tools and add/update LTI consumer credentials <key>:<secret>
+
   -c <hostname>:<secret> Configure with coturn server at <hostname> using <secret> (instead of built-in TURN server)
-  -m <link_path>         Create a Symbolic link from /var/bigbluebutton to <link_path> 
+
+  -m <link_path>         Create a Symbolic link from /var/bigbluebutton to <link_path>
+
   -p <host>[:<port>]     Use apt-get proxy at <host> (default port 3142)
   -r <host>              Use alternative apt repository (such as packages-eu.bigbluebutton.org)
+
   -d                     Skip SSL certificates request (use provided certificates from mounted volume) in /local/certs/
   -w                     Install UFW firewall (recommended)
+
   -j                     Allows the installation of BigBlueButton to proceed even if not all requirements [for production use] are met.
                          Note that not all requirements can be ignored. This is useful in development / testing / ci scenarios.
+
   -i                     Allows the installation of BigBlueButton to proceed even if Apache webserver is installed.
+
   -h                     Print help
+
 OPTIONS (install Let's Encrypt certificate only):
+
   -s <hostname>          Configure server with <hostname> (required)
   -e <email>             Configure email for Let's Encrypt certbot (required)
   -l                     Only install Let's Encrypt certificate (not BigBlueButton)
   -x                     Use Let's Encrypt certbot with manual dns challenges (optional)
+
 OPTIONS (install Greenlight only):
+
   -g                     Install Greenlight version 3 (required)
   -k                     Install Keycloak version 20 (optional)
+
 OPTIONS (install BigBlueButton LTI framework only):
+
   -t <key>:<secret>      Install BigBlueButton LTI framework tools and add/update LTI consumer credentials <key>:<secret> (required)
+
+VARIABLES (configure Greenlight only):
+  GL_PATH                Configure Greenlight relative URL root path (Optional)
+                          * Use this when deploying Greenlight behind a reverse proxy on a path other than the default '/' e.g. '/gl'.
+
+
 EXAMPLES:
+
 Sample options for setup a BigBlueButton 2.6 server
+
     -v focal-260 -s bbb.example.com -e info@example.com
+
 Sample options for setup a BigBlueButton 2.6 server with Greenlight 3 and optionally Keylcoak
+
     -v focal-260 -s bbb.example.com -e info@example.com -g [-k]
-Sample options for setup a BigBlueButton 2.6 server with LTI framework while managing LTI consumer credentials MY_KEY:MY_SECRET 
+
+Sample options for setup a BigBlueButton 2.6 server with LTI framework while managing LTI consumer credentials MY_KEY:MY_SECRET
+
     -v focal-260 -s bbb.example.com -e info@example.com -t MY_KEY:MY_SECRET
+
 SUPPORT:
     Community: https://bigbluebutton.org/support
          Docs: https://github.com/bigbluebutton/bbb-install

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -91,6 +91,11 @@ OPTIONS (install BigBlueButton LTI framework only):
 
   -t <key>:<secret>      Install BigBlueButton LTI framework tools and add/update LTI consumer credentials <key>:<secret> (required)
 
+VARIABLES (configure Greenlight only):
+  GL_PATH                Configure Greenlight relative URL root path (Optional)
+                          * Use this when deploying Greenlight behind a reverse proxy on a path other than the default '/' e.g. '/gl'.
+
+
 EXAMPLES:
 
 Sample options for setup a BigBlueButton 2.6 server
@@ -176,6 +181,13 @@ main() {
         ;;
       g)
         GREENLIGHT=true
+        GL_DEFAULT_PATH=/
+
+        if [ -n "$GL_PATH"  ] && [ "$GL_PATH" != "$GL_DEFAULT_PATH" ]; then
+          if [[ ! $GL_PATH =~ ^/.*[^/]$ ]]; then
+            err "\$GL_PATH ENV is set to '$GL_PATH' which is invalid, Greenlight relative URL root path must start but not end with '/'."
+          fi
+        fi
         ;;
       k)
         INSTALL_KC=true
@@ -192,7 +204,6 @@ main() {
         fi
 
         IFS=: LTI_CREDS=($LTI_CREDS) IFS=' ' # Making LTI_CREDS an array, first element is the LTI TC key and the second is the LTI TC secret.
-        
         ;;
       a)
         err "Error: bbb-demo (API demos, '-a' option) were deprecated in BigBlueButton 2.6. Please use Greenlight or API MATE"
@@ -861,10 +872,9 @@ install_greenlight_v3(){
   # Configuring Greenlight v3 docker-compose.yml (if configured no side effect will happen).
   sed -i "s|^\([ \t-]*POSTGRES_PASSWORD\)\(=[ \t]*\)$|\1=$(openssl rand -hex 24)|g" $GL3_DIR/docker-compose.yml # Do not overwrite the value if not empty.
 
-  
   local PGUSER=postgres # Postgres db user to be used by greenlight-v3.
   local PGTXADDR=postgres:5432 # Postgres DB transport address (pair of (@ip:@port)).
-  local RSTXADDR=redis:6379
+  local RSTXADDR=redis:6379 # Redis DB transport address (pair of (@ip:@port)).
   local PGPASSWORD=$(sed -ne "s/^\([ \t-]*POSTGRES_PASSWORD=\)\(.*\)$/\2/p" $GL3_DIR/docker-compose.yml) # Extract generated Postgres password.
 
   if [ -z "$PGPASSWORD" ]; then
@@ -897,6 +907,8 @@ install_greenlight_v3(){
   #   A simple change can impact that property and therefore render the upgrading functionnality unoperationnal or impact the running system.
 
   # Configuring Greenlight v3 .env file (if already configured this will only update the BBB endpoint and secret).
+  cp -v $GL3_DIR/.env $GL3_DIR/.env.old && say "old .env file can be retrieved at $GL3_DIR/.env.old" #Backup
+
   sed -i "s|^[# \t]*BIGBLUEBUTTON_ENDPOINT=.*|BIGBLUEBUTTON_ENDPOINT=$BIGBLUEBUTTON_URL|" $GL3_DIR/.env
   sed -i "s|^[# \t]*BIGBLUEBUTTON_SECRET=.*|BIGBLUEBUTTON_SECRET=$BIGBLUEBUTTON_SECRET|"  $GL3_DIR/.env
   sed -i "s|^[# \t]*SECRET_KEY_BASE=[ \t]*$|SECRET_KEY_BASE=$SECRET_KEY_BASE|" $GL3_DIR/.env # Do not overwrite the value if not empty.
@@ -984,6 +996,26 @@ install_greenlight_v3(){
     sed -i '/X-Forwarded-Proto/s/$scheme/"https"/' $NGINX_FILES_DEST/keycloak.nginx
   fi
 
+  # Update .env file catching new configurations:
+  if ! grep -q 'RELATIVE_URL_ROOT=' $GL3_DIR/.env; then
+      cat <<HERE >> $GL3_DIR/.env
+#RELATIVE_URL_ROOT=/gl
+
+HERE
+  fi
+
+  if [ -n "$GL_PATH" ]; then
+    sed -i "s|^[# \t]*RELATIVE_URL_ROOT=.*|RELATIVE_URL_ROOT=$GL_PATH|" $GL3_DIR/.env
+  fi
+
+  local GL_RELATIVE_URL_ROOT=$(sed -ne "s/^\([ \t]*RELATIVE_URL_ROOT=\)\(.*\)$/\2/p" $GL3_DIR/.env) # Extract relative URL root path.
+  say "Deploying Greenlight on the '${GL_RELATIVE_URL_ROOT:-$GL_DEFAULT_PATH}' path..."
+
+  if [ -n "$GL_RELATIVE_URL_ROOT" ] && [ "$GL_RELATIVE_URL_ROOT" != "$GL_DEFAULT_PATH" ]; then
+    sed -i "s|^\([ \t]*location\)[ \t]*\(.*/cable\)[ \t]*\({\)$|\1 $GL_RELATIVE_URL_ROOT/cable \3|" $NGINX_FILES_DEST/greenlight-v3.nginx
+    sed -i "s|^\([ \t]*location\)[ \t]*\(@bbb-fe\)[ \t]*\({\)$|\1 $GL_RELATIVE_URL_ROOT \3|" $NGINX_FILES_DEST/greenlight-v3.nginx
+  fi
+
   nginx -qt || err 'greenlight-v3 failed to install/update due to nginx tests failing to pass - if using the official image then please contact the maintainers.'
   nginx -qs reload && say 'greenlight-v3 was successfully configured'
 
@@ -1001,8 +1033,8 @@ install_greenlight_v3(){
   say "starting greenlight-v3..."
   docker-compose -f $GL3_DIR/docker-compose.yml up -d
   sleep 5
-  say "greenlight-v3 is installed, up to date and accessible on: https://$HOST/"
-  say "To create Greenlight administrator account, see: https://docs.bigbluebutton.org/greenlight_v3/gl3-install.html#creating-an-admin-account-1"
+  say "greenlight-v3 is now installed and accessible on: https://$HOST${GL_RELATIVE_URL_ROOT:-$GL_DEFAULT_PATH}"
+  say "To create Greenlight administrator account, see: https://docs.bigbluebutton.org/greenlight/v3/install#creating-an-admin-account"
 
 
   if grep -q 'keycloak:' $GL3_DIR/docker-compose.yml; then
@@ -1013,7 +1045,7 @@ install_greenlight_v3(){
       say "   $KCPASSWORD"
     fi
 
-    say "To complete the configuration of Keycloak, see: https://docs.bigbluebutton.org/greenlight_v3/gl3-external-authentication.html#configuring-keycloak"
+    say "To complete the configuration of Keycloak, see: https://docs.bigbluebutton.org/greenlight/v3/external-authentication#configuring-keycloak"
   fi
 
   return 0;
@@ -1185,6 +1217,8 @@ install_lti_tool() {
   #   A simple change can impact that property and therefore render the upgrading functionnality unoperationnal or impact the running system.
 
   # Configuring BBB LTI .env file (if already configured this will only update some expected or safe to change variables).
+  cp -v $LTI_APP_DIR/.env $LTI_APP_DIR/.env.old && say "old $LOG_NAME .env file can be retrieved at $LTI_APP_DIR/.env.old" #Backup
+
   sed -i "s|^[# \t]*SECRET_KEY_BASE=[ \t]*$|SECRET_KEY_BASE=$SECRET_KEY_BASE|" $LTI_APP_DIR/.env # Do not overwrite the value if not empty.
   sed -i "s|^[# \t]*BIGBLUEBUTTON_ENDPOINT=.*|BIGBLUEBUTTON_ENDPOINT=$BIGBLUEBUTTON_URL|" $LTI_APP_DIR/.env
   sed -i "s|^[# \t]*BIGBLUEBUTTON_SECRET=.*|BIGBLUEBUTTON_SECRET=$BIGBLUEBUTTON_SECRET|"  $LTI_APP_DIR/.env


### PR DESCRIPTION
This PR adds support for Greenlight 3 relative URL root path configuration via the `bbb-install-2.6` script.

USAGE:
- To change Greenlight path, one need to trigger an upgrade to the application by simply running the `bbb-install-2.6` script with the `-g` option included and with the `GL_PATH` shell environmental variable declared and set to the preferred relative path.

Example:
To deploy Greenlight 3 on a relative URL root path of `/a/b/c` instead of the default root path of '/' one could install/upgrade the system by running the script as follow:

```bash
GL_PATH=/a/b/c bbb-install-2.6.sh [options] -g
```
IF using wget:
```bash
wget -qO- https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh | GL_PATH=/a/b/c bash -s -- [options] -g
```


>  Notice the use of a single leading but no trailing slashes.

To change the deployment back to '/' :

```bash
GL_PATH=/ bbb-install-2.6.sh [options] -g
```
IF using wget:
```bash
wget -qO- https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh | GL_PATH=/ bash -s -- [options] -g
```


> Admins can change their deployment as much as they want and anytime they want, however we don't recommend doing that too frequently to avoid disrupting users. 
