### PR TITLE
Have nginx generate relative redirects behind haproxy

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -1515,9 +1515,11 @@ server {
   listen [::1]:81;
   server_name $HOST;
 
+  # nginx does not know its external port/protocol behind haproxy, so use relative redirects.
+  absolute_redirect off;
     
-    # HSTS (comment out to enable)
-    #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  # HSTS (uncomment to enable)
+  #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 

--- a/bbb-install-2.7.sh
+++ b/bbb-install-2.7.sh
@@ -1514,9 +1514,11 @@ server {
   listen [::1]:81;
   server_name $HOST;
 
+  # nginx does not know its external port/protocol behind haproxy, so use relative redirects.
+  absolute_redirect off;
     
-    # HSTS (comment out to enable)
-    #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  # HSTS (uncomment to enable)
+  #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 


### PR DESCRIPTION
When using nginx reverse proxied behind haproxy, nginx does not know its external port or url scheme, so it generates incorrect absolute redirects. Have it generate relative redirects (path-only redirects) instead. This fixes nginx-generated redirects for things like adding a trailing slash to a directory name.

Fixes #631