### PR TITLE
Set $real_scheme variable in nginx config

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -1523,6 +1523,10 @@ server {
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
+  # This variable is used instead of \$scheme by bigbluebutton nginx include
+  # files, so \$scheme can be overridden in reverse-proxy configurations.
+  set \$real_scheme "https";
+
   # BigBlueButton landing page.
   location / {
     root   /var/www/bigbluebutton-default/assets;
@@ -1575,6 +1579,10 @@ server {
     #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
+
+  # This variable is used instead of \$scheme by bigbluebutton nginx include
+  # files, so \$scheme can be overridden in reverse-proxy configurations.
+  set \$real_scheme \$scheme;
 
   # BigBlueButton landing page.
   location / {

--- a/bbb-install-2.7.sh
+++ b/bbb-install-2.7.sh
@@ -1495,8 +1495,9 @@ server {
 
   location = /.well-known/acme-challenge/ {
     return 404;
-  }  
+  }
 }
+
 set_real_ip_from 127.0.0.1;
 real_ip_header proxy_protocol;
 real_ip_recursive on;
@@ -1522,6 +1523,10 @@ server {
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
 
+  # This variable is used instead of \$scheme by bigbluebutton nginx include
+  # files, so \$scheme can be overridden in reverse-proxy configurations.
+  set \$real_scheme "https";
+
   # BigBlueButton landing page.
   location / {
     root   /var/www/bigbluebutton-default/assets;
@@ -1541,7 +1546,7 @@ server {
   listen 80;
   listen [::]:80;
   server_name $HOST;
-  
+
   location ^~ / {
     return 301 https://\$server_name\$request_uri; #redirect HTTP to HTTPS
   }
@@ -1574,6 +1579,10 @@ server {
     #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
   access_log  /var/log/nginx/bigbluebutton.access.log;
+
+  # This variable is used instead of \$scheme by bigbluebutton nginx include
+  # files, so \$scheme can be overridden in reverse-proxy configurations.
+  set \$real_scheme \$scheme;
 
   # BigBlueButton landing page.
   location / {


### PR DESCRIPTION
Updates to BigBlueButton in https://github.com/bigbluebutton/bigbluebutton/pull/17732 require that the /etc/nginx/sites-available/bigbluebutton file sets the $real_scheme variable as appropriate for the listener and reverse proxy situation.

When nginx is terminating ssl itself, set it to the value of `$scheme`, same as the config file shipped with BigBlueButton. When nginx is being reverse-proxied behind haproxy, set this variable to the fixed string `"https"` since nginx does not have any way of knowing that the original connection had been made using TLS.

A couple of stray formatting changes (newlines, trailing spaces) snuck in to sync the bbb 2.6 and 2.7 versions of the script to each-other.