### PR TITLE
fix: Add /assets to root to allow for certs renewal

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -1490,7 +1490,7 @@ server {
   location ^~ /.well-known/acme-challenge/ {
     allow all;
     default_type "text/plain";
-    root /var/www/bigbluebutton-default;
+    root /var/www/bigbluebutton-default/assets;
   }
 
   location = /.well-known/acme-challenge/ {
@@ -1554,7 +1554,7 @@ server {
   location ^~ /.well-known/acme-challenge/ {
     allow all;
     default_type "text/plain";
-    root /var/www/bigbluebutton-default;
+    root /var/www/bigbluebutton-default/assets;
   }
 
   location = /.well-known/acme-challenge/ {


### PR DESCRIPTION
A follow up to https://github.com/bigbluebutton/bbb-install/commit/4e6622741bb5a37c7b12d10a9325a0e25fa21360
to include changes made in https://github.com/bigbluebutton/bbb-install/commit/89eccdcddbca317ec652821643fac5433646f39d and https://github.com/bigbluebutton/bbb-install/pull/540 

credits for spotting this @kepstin 