### PR TITLE
Upgrade node16 to node18

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -292,16 +292,16 @@ main() {
 
     rm -rf /etc/apt/sources.list.d/kurento.list     # Kurento 6.15 now packaged with 2.3
 
-    if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 12 /etc/apt/sources.list.d/nodesource.list; then
+    if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 16 /etc/apt/sources.list.d/nodesource.list; then
       # Node 12 might be installed, previously used in BigBlueButton
       sudo apt-get purge nodejs
       sudo rm -r /etc/apt/sources.list.d/nodesource.list
     fi
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
-      curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+      curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
     fi
-    if ! apt-cache madison nodejs | grep -q node_16; then
-      err "Did not detect nodejs 16.x candidate for installation"
+    if ! apt-cache madison nodejs | grep -q node_18; then
+      err "Did not detect nodejs 18.x candidate for installation"
     fi
     if ! apt-key list MongoDB | grep -q 4.4; then
       wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -293,7 +293,7 @@ main() {
     rm -rf /etc/apt/sources.list.d/kurento.list     # Kurento 6.15 now packaged with 2.3
 
     if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 16 /etc/apt/sources.list.d/nodesource.list; then
-      # Node 12 might be installed, previously used in BigBlueButton
+      # Node 16 might be installed, previously used in BigBlueButton
       sudo apt-get purge nodejs
       sudo rm -r /etc/apt/sources.list.d/nodesource.list
     fi


### PR DESCRIPTION
Reason:
NodeJS 16 will become unsupported EOL on Sept 11, 2023 https://nodejs.org/en/blog/announcements/nodejs16-eol

Tested with NodeJS v16.20.0 upgrading to v18.16.0 (and all worked well):
- bbb-pads
- bbb-webrtc-sfu
- bbb-export-annotations
- etherpad-lite


Special cases:
- I could not test with `bbb-webhooks` because of blocker https://github.com/bigbluebutton/bigbluebutton/issues/18142
- `bbb-html5` ships with its own version of nodejs, still stuck at v14 until Meteor 3.0 is released and we adopt it fully. Until then Meteor provides patches to v14. https://github.com/bigbluebutton/bigbluebutton/pull/17790