### PR TITLE
Fix #656

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -817,7 +817,7 @@ END
   cat > /etc/letsencrypt/renewal-hooks/deploy/haproxy <<HERE
 #!/bin/bash -e
 
-cat "/etc/letsencrypt/live/${HOST}"/{fullchain,privkey}.pem > /etc/haproxy/certbundle.pem.new
+{ cat /etc/letsencrypt/live/$HOST/fullchain.pem; echo; cat /etc/letsencrypt/live/$HOST/privkey.pem; } > /etc/haproxy/certbundle.pem.new
 chown root:haproxy /etc/haproxy/certbundle.pem.new
 chmod 0640 /etc/haproxy/certbundle.pem.new
 mv /etc/haproxy/certbundle.pem.new /etc/haproxy/certbundle.pem


### PR DESCRIPTION
Ensure there is a space between `-----END CERTIFICATE-----` and `-----BEGIN PRIVATE KEY-----` when creating `/etc/haproxy/certbundle.pem`.