### PR TITLE
First steps on BBB 2.8 bbb-install.sh

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1374,9 +1374,6 @@ install_docker() {
   need_pkg apt-transport-https ca-certificates curl gnupg-agent software-properties-common openssl
 
   # Install Docker
-
-  exit
-
   if ! apt-key list | grep -q Docker; then
     if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then
       curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -272,8 +272,7 @@ main() {
   check_cpus
   check_ipv6
 
-  need_pkg software-properties-common  # needed for add-apt-repository
-  sudo add-apt-repository universe
+  need_ppa universe
   need_pkg wget curl gpg-agent dirmngr apparmor-utils
 
   # need_pkg xmlstarlet
@@ -1421,7 +1420,7 @@ install_ssl() {
   mkdir -p /etc/nginx/ssl
 
   if [ -z "$PROVIDED_CERTIFICATE" ]; then
-    add-apt-repository universe
+    need_ppa universe
     apt-get update
     need_pkg certbot
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -272,7 +272,6 @@ main() {
   check_cpus
   check_ipv6
 
-  need_ppa universe
   need_pkg wget curl gpg-agent dirmngr apparmor-utils
 
   # need_pkg xmlstarlet
@@ -1420,7 +1419,6 @@ install_ssl() {
   mkdir -p /etc/nginx/ssl
 
   if [ -z "$PROVIDED_CERTIFICATE" ]; then
-    need_ppa universe
     apt-get update
     need_pkg certbot
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -280,7 +280,8 @@ main() {
   if [ "$DISTRO" == "jammy" ]; then
     need_pkg ca-certificates
 
-    need_ppa rmescandon-ubuntu-yq-jammy.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
+    #need_ppa rmescandon-ubuntu-yq-jammy.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
+    need_ppa ppa:rmescandon/yq
     need_pkg yq
     yq --version
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 # Copyright (c) 2023 BigBlueButton Inc.
 #

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -280,8 +280,8 @@ main() {
   if [ "$DISTRO" == "jammy" ]; then
     need_pkg ca-certificates
 
-    #need_ppa rmescandon-ubuntu-yq-jammy.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
-    need_ppa ppa:rmescandon/yq
+    need_ppa rmescandon-ubuntu-yq-jammy.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
+    #need_ppa ppa:rmescandon/yq
     need_pkg yq
     yq --version
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1374,6 +1374,9 @@ install_docker() {
   need_pkg apt-transport-https ca-certificates curl gnupg-agent software-properties-common openssl
 
   # Install Docker
+
+  exit
+
   if ! apt-key list | grep -q Docker; then
     if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then
       curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg


### PR DESCRIPTION
First pass on `bbb-install.sh` for BigBlueButton 2.8
Highlights (some already backported to BBB 2.7)
* Ubuntu 22.04
* NodeJS 18 (backported)
* MongoDB 6
* yq 4
* no Kurento

Most of this work was done during BigBlueButton Summit in Porto Alegre (April 2023)