### PR TITLE
Fix: Remove Turn errors on Coturn startup

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -1798,7 +1798,6 @@ max-port=65535
 verbose
 
 fingerprint
-lt-cred-mech
 use-auth-secret
 static-auth-secret=$COTURN_SECRET
 realm=$HOST
@@ -1806,8 +1805,11 @@ realm=$HOST
 keep-address-family
 
 no-cli
-no-tlsv1
-no-tlsv1_1
+# Cli password although not used need not be empty!
+cli-password=dummypassword
+# Only listening locally non encrypted (TLS termination by haproxy)
+no-tls
+no-dtls
 
 # Block connections to IP ranges which shouldn't be reachable
 no-loopback-peers


### PR DESCRIPTION
Hi,

This is a fix for Coturn default configuration set in bbb-install-2.6.sh:

- TLS and DTLS for Coturn is unneeded locally and must be disabled (TLS termination is done by haproxy)
```
0: WARNING: cannot find certificate file: turn_server_cert.pem (1)
0: WARNING: cannot start TLS and DTLS listeners because certificate file is not set properly
0: WARNING: cannot find private key file: turn_server_pkey.pem (1)
0: WARNING: cannot start TLS and DTLS listeners because private key file is not set properly
```
- "lt-cred-mech" is incompatible with "use-auth-secret" so removing it
```
CONFIGURATION ALERT: You specified --lt-cred-mech and --use-auth-secret in the same time.
Be aware that you could not mix the username/password and the shared secret based auth methohds. 
Shared secret overrides username/password based auth method. Check your configuration!
```
- "cli-password" need not be empty although not used
```
CONFIG ERROR: Empty cli-password, and so telnet cli interface is disabled! Please set a non empty cli-password!
```