### PR TITLE
2.6: Adapt to new recommended approach for installing NodeJS

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -297,7 +297,10 @@ main() {
       sudo rm -r /etc/apt/sources.list.d/nodesource.list
     fi
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
-      curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+      sudo mkdir -p /etc/apt/keyrings
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      NODE_MAJOR=18
+      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
     fi
     if ! apt-cache madison nodejs | grep -q node_18; then
       err "Did not detect nodejs 18.x candidate for installation"

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -301,6 +301,7 @@ main() {
       curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
       NODE_MAJOR=18
       echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+      force_update_sources
     fi
     if ! apt-cache madison nodejs | grep -q node_18; then
       err "Did not detect nodejs 18.x candidate for installation"
@@ -544,6 +545,17 @@ get_IP() {
   fi
 
   if [ -z "$IP" ]; then err "Unable to determine local IP address."; fi
+}
+
+force_update_sources() {
+  check_root
+  while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg lock"; sleep 1; done
+
+  if [ ! "$SOURCES_FETCHED" = true ]; then
+    apt-get update
+    SOURCES_FETCHED=true
+  fi
+  while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg lock"; sleep 1; done
 }
 
 need_pkg() {

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -301,10 +301,6 @@ main() {
       curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
       NODE_MAJOR=18
       echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-      force_update_sources
-    fi
-    if ! apt-cache madison nodejs | grep -q node_18; then
-      err "Did not detect nodejs 18.x candidate for installation"
     fi
     if ! apt-key list MongoDB | grep -q 4.4; then
       wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
@@ -545,17 +541,6 @@ get_IP() {
   fi
 
   if [ -z "$IP" ]; then err "Unable to determine local IP address."; fi
-}
-
-force_update_sources() {
-  check_root
-  while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg lock"; sleep 1; done
-
-  if [ ! "$SOURCES_FETCHED" = true ]; then
-    apt-get update
-    SOURCES_FETCHED=true
-  fi
-  while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg lock"; sleep 1; done
 }
 
 need_pkg() {


### PR DESCRIPTION
When running bbb-install lately it's been showing the following message:

```
================================================================================
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
================================================================================

                           SCRIPT DEPRECATION WARNING                    

  
  This script, located at https://deb.nodesource.com/setup_X, used to
  install Node.js is deprecated now and will eventually be made inactive.

  Please visit the NodeSource distributions Github and follow the
  instructions to migrate your repo.
  https://github.com/nodesource/distributions

  The NodeSource Node.js Linux distributions GitHub repository contains
  information about which versions of Node.js and which Linux distributions
  are supported and how to install it.
  https://github.com/nodesource/distributions


                          SCRIPT DEPRECATION WARNING

================================================================================
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
================================================================================
```

I adapted bbb-install-2.6.sh to use this newer approach.
I had to remove the `madison` check because it kept triggering every time unless I forced an `apt update`. However, even when forcing it (via a lock aware function), I was having false positives. In all my testing without this check, I could not hit an issue...

This change will be carried forward to BBB 2.7's bbb-install.sh and after to BBB 2.8's.

Source: https://github.com/nodesource/distributions#installation-instructions