### PR TITLE
2.6: Remove purge nodejs step

### DIFF
--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -293,7 +293,7 @@ main() {
 
     if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 16 /etc/apt/sources.list.d/nodesource.list; then
       # Node 16 might be installed, previously used in BigBlueButton
-      sudo apt-get purge nodejs
+      # We will upgrade it rather than purge plus fresh install of a newer version.
       sudo rm -r /etc/apt/sources.list.d/nodesource.list
     fi
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then

--- a/bbb-install-2.6.sh
+++ b/bbb-install-2.6.sh
@@ -293,7 +293,8 @@ main() {
 
     if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 16 /etc/apt/sources.list.d/nodesource.list; then
       # Node 16 might be installed, previously used in BigBlueButton
-      # We will upgrade it rather than purge plus fresh install of a newer version.
+      # Remove the repository config. This will cause the repository to get
+      # re-added using the current nodejs version, and nodejs will be upgraded.
       sudo rm -r /etc/apt/sources.list.d/nodesource.list
     fi
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then


### PR DESCRIPTION
Way less invasive than purging is to remove the source description and to (in the next step) include the source of the newer nodejs.
Thus we don't mark most of BBB packages obsolete for most of the installation process.
Credits for the idea go to @kepstin 