### PR TITLE
Security fix: Avoid making certificate key world-readable on renewal.

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -831,9 +831,10 @@ END
   cat > /etc/letsencrypt/renewal-hooks/deploy/haproxy <<HERE
 #!/bin/bash -e
 
-{ cat /etc/letsencrypt/live/$HOST/fullchain.pem; echo; cat /etc/letsencrypt/live/$HOST/privkey.pem; } > /etc/haproxy/certbundle.pem.new
-chown root:haproxy /etc/haproxy/certbundle.pem.new
+{ touch /etc/haproxy/certbundle.pem.new
 chmod 0640 /etc/haproxy/certbundle.pem.new
+cat /etc/letsencrypt/live/$HOST/fullchain.pem; echo; cat /etc/letsencrypt/live/$HOST/privkey.pem; } > /etc/haproxy/certbundle.pem.new
+chown root:haproxy /etc/haproxy/certbundle.pem.new
 mv /etc/haproxy/certbundle.pem.new /etc/haproxy/certbundle.pem
 systemctl reload haproxy
 HERE

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -831,9 +831,10 @@ END
   cat > /etc/letsencrypt/renewal-hooks/deploy/haproxy <<HERE
 #!/bin/bash -e
 
-{ touch /etc/haproxy/certbundle.pem.new
+touch /etc/haproxy/certbundle.pem.new
 chmod 0640 /etc/haproxy/certbundle.pem.new
-cat /etc/letsencrypt/live/$HOST/fullchain.pem; echo; cat /etc/letsencrypt/live/$HOST/privkey.pem; } > /etc/haproxy/certbundle.pem.new
+
+{ cat /etc/letsencrypt/live/$HOST/fullchain.pem; echo; cat /etc/letsencrypt/live/$HOST/privkey.pem; } > /etc/haproxy/certbundle.pem.new
 chown root:haproxy /etc/haproxy/certbundle.pem.new
 mv /etc/haproxy/certbundle.pem.new /etc/haproxy/certbundle.pem
 systemctl reload haproxy


### PR DESCRIPTION
certbundle.new should be created and protected with chmod *before* the secret key is copied into it. Otherwise, though temporarily, the key becomes world readable and might be read by a local user monitoring the folder.