### PR TITLE
Added extra check to ensure apt-get is not in use

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -561,7 +561,8 @@ need_pkg() {
   if ! dpkg -s "${@}" >/dev/null 2>&1; then
     LC_CTYPE=C.UTF-8 apt-get install -yq "${@}"
   fi
-  while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg lock"; sleep 1; done
+  while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg/lock is in use"; sleep 1; done
+  while lsof /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do echo "Sleeping for 1 second because dpkg/lock-frontend in use"; sleep 1; done
 }
 
 need_ppa() {


### PR DESCRIPTION
Avoid this error

```Reading package lists...
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 14755 (apt-get)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
bbb-install: Docker did not install
