### PR TITLE
fix: avoid overwriting postgresql.gpg

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -314,7 +314,9 @@ main() {
 
     # postgres for BigBlueButton core
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+    if [ ! -f /etc/apt/trusted.gpg.d/postgresql.gpg ]; then
+      curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+    fi
 
     touch /root/.rnd
     MONGODB=mongodb-org


### PR DESCRIPTION
Seeing
`File '/etc/apt/trusted.gpg.d/postgresql.gpg' exists. Overwrite? (y/N)`
when repeatedly running bbb-install.