### PR TITLE
Add sudo to ensure bigbluebutton.asc can be created

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -583,7 +583,7 @@ check_version() {
   check_root
   need_pkg apt-transport-https
   if ! apt-key list | grep -q "BigBlueButton apt-get"; then
-    curl -fsSL "https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc" | tee /etc/apt/keyrings/bigbluebutton.asc
+    curl -fsSL "https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc" | sudo tee /etc/apt/keyrings/bigbluebutton.asc
   fi
 
   echo "deb [signed-by=/etc/apt/keyrings/bigbluebutton.asc] https://$PACKAGE_REPOSITORY/$VERSION bigbluebutton-$DISTRO main" > /etc/apt/sources.list.d/bigbluebutton.list


### PR DESCRIPTION
Related to https://github.com/bigbluebutton/bbb-install/commit/9e8778fab4e751ef1eeac6deccc7106957cee1c5

Adding `sudo` in front of `tee` command to ensure the .asc file can be created. This was an issue when running the script as a non-root user.