### PR TITLE
add `need_pkg curl` before using curl in `check_version`

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -581,7 +581,7 @@ check_version() {
     err "Unable to locate packages for $1 at $PACKAGE_REPOSITORY."
   fi
   check_root
-  need_pkg apt-transport-https
+  need_pkg curl apt-transport-https
   if ! apt-key list | grep -q "BigBlueButton apt-get"; then
     curl -fsSL "https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc" | sudo tee /etc/apt/keyrings/bigbluebutton.asc
   fi


### PR DESCRIPTION
Commit https://github.com/bigbluebutton/bbb-install/commit/9e8778fab4e751ef1eeac6deccc7106957cee1c5 introduced usage of curl before curl would be installed in a later need_pkg line. This PR makes sure curl is already installed when used at this earlier point in the script. The second `need_pkg curl` is left in place, because it doesn't hurt and might prevent future breakage.

Presumably fixes https://github.com/bigbluebutton/bbb-install/issues/743, but I did not actually test it yet. 