### PR TITLE
Drop one more use of apt-key

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -582,10 +582,7 @@ check_version() {
   fi
   check_root
   need_pkg curl apt-transport-https
-  if ! apt-key list | grep -q "BigBlueButton apt-get"; then
-    curl -fsSL "https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc" | sudo tee /etc/apt/keyrings/bigbluebutton.asc
-  fi
-
+  curl -fsSL "https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc" | sudo tee /etc/apt/keyrings/bigbluebutton.asc
   echo "deb [signed-by=/etc/apt/keyrings/bigbluebutton.asc] https://$PACKAGE_REPOSITORY/$VERSION bigbluebutton-$DISTRO main" > /etc/apt/sources.list.d/bigbluebutton.list
 }
 


### PR DESCRIPTION
Without this change when I run bbb-install.sh on a 3.0 server installed before the merging of #739 
the server does not upgrade. The error I see is:

```
Err:15 https://ubuntu.bigbluebutton.org/jammy-30-dev bigbluebutton-jammy InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 37B5DD5EFAB46452
Reading package lists... Done
W: GPG error: https://ubuntu.bigbluebutton.org/jammy-30-dev bigbluebutton-jammy InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 37B5DD5EFAB46452
```

When I manually run

`curl -fsSL "https://ubuntu.bigbluebutton.org/repo/bigbluebutton.asc" | tee /etc/apt/keyrings/bigbluebutton.asc`
`echo "deb [signed-by=/etc/apt/keyrings/bigbluebutton.asc] https://ubuntu.bigbluebutton.org/jammy-30-dev bigbluebutton-jammy main" > /etc/apt/sources.list.d/bigbluebutton.list`
It appears to be resolved for good.