### PR TITLE
Drop mongo, bump nodejs to 22

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -290,7 +290,7 @@ main() {
     need_ppa bigbluebutton-ubuntu-support-focal.list ppa:bigbluebutton/support  2E1B01D0E95B94BC    # Needed for libopusenc0
     need_ppa martin-uni-mainz-ubuntu-coturn-focal.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
 
-    if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 16 /etc/apt/sources.list.d/nodesource.list; then
+    if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
       # Node 16 might be installed, previously used in BigBlueButton
       # Remove the repository config. This will cause the repository to get
       # re-added using the current nodejs version, and nodejs will be upgraded.
@@ -299,18 +299,9 @@ main() {
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
       sudo mkdir -p /etc/apt/keyrings
       curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-      NODE_MAJOR=18
+      NODE_MAJOR=22
       echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
     fi
-
-   if [ ! -f /usr/share/keyrings/mongodb-server-6.0.gpg ]; then
-     curl -fsSL https://pgp.mongodb.com/server-6.0.asc | \
-     sudo gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg \
-     --dearmor
-   fi
-
-   echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | \
-   sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
     # postgres for BigBlueButton core
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -319,7 +310,6 @@ main() {
     fi
 
     touch /root/.rnd
-    MONGODB=mongodb-org
     install_docker		                     # needed for bbb-libreoffice-docker
     need_pkg ruby
 
@@ -332,7 +322,7 @@ main() {
   apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
-  need_pkg nodejs "$MONGODB" apt-transport-https haveged
+  need_pkg nodejs apt-transport-https haveged
   need_pkg bigbluebutton
   need_pkg bbb-html5
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -298,6 +298,9 @@ main() {
     fi
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
       sudo mkdir -p /etc/apt/keyrings
+      if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
+        rm /etc/apt/keyrings/nodesource.gpg
+      fi
       curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
       NODE_MAJOR=22
       echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -309,7 +309,16 @@ main() {
     which node
     which nodejs
 
-    sudo apt remove nodejs
+    # sudo apt remove nodejs
+    sudo rm /usr/bin/nodejs
+    sudo rm /usr/local/bin/nodejs
+    sudo ln -s "$(which node)" /usr/local/bin/nodejs
+    node -v
+    nodejs -v
+    which node
+    which nodejs
+    # at this point we still have nodejs 18 if we're upgrading from an earlier 3.0 alpha but it's not in use
+    # 22 is the one in use. We can't just remove nodejs via apt remove because that also removes bbb packages
     
 
     # if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
@@ -347,7 +356,7 @@ main() {
   apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
-  need_pkg nodejs apt-transport-https haveged
+  need_pkg apt-transport-https haveged
   need_pkg bigbluebutton
   need_pkg bbb-html5
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -309,7 +309,7 @@ main() {
     which node
     which nodejs
 
-    # sudo apt remove nodejs
+    sudo apt remove nodejs
     
 
     # if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -292,50 +292,50 @@ main() {
 
     # install node
 
-    if command -v nvm &> /dev/null
-    then
-      echo "nvm is already installed."
-    else
-      echo "nvm is not installed."
-      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-      source ~/.nvm/nvm.sh
-    fi
-    nvm install 22
-    nvm use 22
-    nvm alias default 22
+    # if command -v nvm &> /dev/null
+    # then
+    #   echo "nvm is already installed."
+    # else
+    #   echo "nvm is not installed."
+    #   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+    #   source ~/.nvm/nvm.sh
+    # fi
+    # nvm install 22
+    # nvm use 22
+    # nvm alias default 22
 
-    node -v
-    nodejs -v
-    which node
-    which nodejs
+    # node -v
+    # nodejs -v
+    # which node
+    # which nodejs
 
-    # sudo apt remove nodejs
-    sudo rm /usr/bin/nodejs
-    sudo rm /usr/local/bin/nodejs
-    sudo ln -s "$(which node)" /usr/local/bin/nodejs
-    node -v
-    nodejs -v
-    which node
-    which nodejs
-    # at this point we still have nodejs 18 if we're upgrading from an earlier 3.0 alpha but it's not in use
-    # 22 is the one in use. We can't just remove nodejs via apt remove because that also removes bbb packages
+    # # sudo apt remove nodejs
+    # sudo rm /usr/bin/nodejs
+    # sudo rm /usr/local/bin/nodejs
+    # sudo ln -s "$(which node)" /usr/local/bin/nodejs
+    # node -v
+    # nodejs -v
+    # which node
+    # which nodejs
+    # # at this point we still have nodejs 18 if we're upgrading from an earlier 3.0 alpha but it's not in use
+    # # 22 is the one in use. We can't just remove nodejs via apt remove because that also removes bbb packages
     
 
-    # if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
-    #   # Node 16 might be installed, previously used in BigBlueButton
-    #   # Remove the repository config. This will cause the repository to get
-    #   # re-added using the current nodejs version, and nodejs will be upgraded.
-    #   sudo rm -r /etc/apt/sources.list.d/nodesource.list
-    # fi
-    # if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
-    #   sudo mkdir -p /etc/apt/keyrings
-    #   if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
-    #     rm /etc/apt/keyrings/nodesource.gpg
-    #   fi
-    #   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-    #   NODE_MAJOR=22
-    #   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-    # fi
+    if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
+      # Node 18 might be installed, previously used in BigBlueButton
+      # Remove the repository config. This will cause the repository to get
+      # re-added using the current nodejs version, and nodejs will be upgraded.
+      sudo rm -r /etc/apt/sources.list.d/nodesource.list
+    fi
+    if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
+      sudo mkdir -p /etc/apt/keyrings
+      if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
+        rm /etc/apt/keyrings/nodesource.gpg
+      fi
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      NODE_MAJOR=22
+      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+    fi
 
     # postgres for BigBlueButton core
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -290,21 +290,43 @@ main() {
     need_ppa bigbluebutton-ubuntu-support-focal.list ppa:bigbluebutton/support  2E1B01D0E95B94BC    # Needed for libopusenc0
     need_ppa martin-uni-mainz-ubuntu-coturn-focal.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
 
-    if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
-      # Node 16 might be installed, previously used in BigBlueButton
-      # Remove the repository config. This will cause the repository to get
-      # re-added using the current nodejs version, and nodejs will be upgraded.
-      sudo rm -r /etc/apt/sources.list.d/nodesource.list
+    # install node
+
+    if command -v nvm &> /dev/null
+    then
+      echo "nvm is already installed."
+    else
+      echo "nvm is not installed."
+      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+      source ~/.nvm/nvm.sh
     fi
-    if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
-      sudo mkdir -p /etc/apt/keyrings
-      if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
-        rm /etc/apt/keyrings/nodesource.gpg
-      fi
-      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-      NODE_MAJOR=22
-      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-    fi
+    nvm install 22
+    nvm use 22
+    nvm alias default 22
+
+    node -v
+    nodejs -v
+    which node
+    which nodejs
+
+    # sudo apt remove nodejs
+    
+
+    # if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
+    #   # Node 16 might be installed, previously used in BigBlueButton
+    #   # Remove the repository config. This will cause the repository to get
+    #   # re-added using the current nodejs version, and nodejs will be upgraded.
+    #   sudo rm -r /etc/apt/sources.list.d/nodesource.list
+    # fi
+    # if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
+    #   sudo mkdir -p /etc/apt/keyrings
+    #   if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
+    #     rm /etc/apt/keyrings/nodesource.gpg
+    #   fi
+    #   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    #   NODE_MAJOR=22
+    #   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+    # fi
 
     # postgres for BigBlueButton core
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -290,37 +290,6 @@ main() {
     need_ppa bigbluebutton-ubuntu-support-focal.list ppa:bigbluebutton/support  2E1B01D0E95B94BC    # Needed for libopusenc0
     need_ppa martin-uni-mainz-ubuntu-coturn-focal.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
 
-    # install node
-
-    # if command -v nvm &> /dev/null
-    # then
-    #   echo "nvm is already installed."
-    # else
-    #   echo "nvm is not installed."
-    #   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-    #   source ~/.nvm/nvm.sh
-    # fi
-    # nvm install 22
-    # nvm use 22
-    # nvm alias default 22
-
-    # node -v
-    # nodejs -v
-    # which node
-    # which nodejs
-
-    # # sudo apt remove nodejs
-    # sudo rm /usr/bin/nodejs
-    # sudo rm /usr/local/bin/nodejs
-    # sudo ln -s "$(which node)" /usr/local/bin/nodejs
-    # node -v
-    # nodejs -v
-    # which node
-    # which nodejs
-    # # at this point we still have nodejs 18 if we're upgrading from an earlier 3.0 alpha but it's not in use
-    # # 22 is the one in use. We can't just remove nodejs via apt remove because that also removes bbb packages
-    
-
     if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
       # Node 18 might be installed, previously used in BigBlueButton
       # Remove the repository config. This will cause the repository to get


### PR DESCRIPTION
Changes needed for the dropping of Meteor (Mongo), see https://github.com/bigbluebutton/bigbluebutton/pull/20811

Merging this PR means we can no longer install BBB 3.0.0-alpha.7 or earlier.

Closes https://github.com/bigbluebutton/bbb-install/issues/261