### PR TITLE
Fix apt-keys deprecation,and set a standard for where keys should go

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -278,17 +278,53 @@ main() {
   get_IP "$HOST"
 
   if [ "$DISTRO" == "jammy" ]; then
+    
     need_pkg ca-certificates
 
-    need_ppa rmescandon-ubuntu-yq-jammy.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
-    #need_ppa ppa:rmescandon/yq
-    need_pkg yq
-    yq --version
+
+    #ppa:rmescandon/yq installation
+    if [ -f /etc/apt/sources.list.d/rmescandon-ubuntu-yq-jammy.list ] &&  grep -q 18 /etc/apt/sources.list.d/rmescandon-ubuntu-yq-jammy.list; then
+        sudo rm -r /etc/apt/sources.list.d/rmescandon-ubuntu-yq-jammy.list
+        fi
+        if [ ! -f /etc/apt/sources.list.d/rmescandon-ubuntu-yq-jammy.list ]; then
+        if [ -f /etc/apt/keyrings/rmescandon-ubuntu-yq.gpg  ]; then
+            rm  -r /etc/apt/keyrings/rmescandon-ubuntu-yq.gpg  
+        fi
+        curl -fsSL "https://ppa.launchpadcontent.net/rmescandon/yq/ubuntu/dists/jammy/Release.gpg" -o /etc/apt/keyrings/rmescandon-ubuntu-yq-release.gpg
+        curl -sL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x6657DBE0CC86BB64' | gpg --dearmor > /etc/apt/keyrings/rmescandon-ubuntu-yq.gpg 
+        rm -r /etc/apt/keyrings/rmescandon-ubuntu-yq-release.gpg 
+        echo "deb [signed-by=/etc/apt/keyrings/rmescandon-ubuntu-yq.gpg]  https://ppa.launchpadcontent.net/rmescandon/yq/ubuntu/  jammy main" > /etc/apt/sources.list.d/rmescandon-ubuntu-yq-jammy.list
+
+        fi
 
     #need_ppa libreoffice-ubuntu-ppa-jammy.list       ppa:libreoffice/ppa        1378B444 # Latest version of libreoffice
-
-    need_ppa bigbluebutton-ubuntu-support-focal.list ppa:bigbluebutton/support  2E1B01D0E95B94BC    # Needed for libopusenc0
-    need_ppa martin-uni-mainz-ubuntu-coturn-focal.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
+    
+    #BigBlueButton support
+    if [ -f /etc/apt/sources.list.d/bigbluebutton-ubuntu-support-jammy.list ] &&  grep -q 18 /etc/apt/sources.list.d/bigbluebutton-ubuntu-support-jammy.list; then
+      sudo rm -r /etc/apt/sources.list.d/bigbluebutton-ubuntu-support-jammy.list
+    fi
+    if [ ! -f /etc/apt/sources.list.d/bigbluebutton-ubuntu-support-jammy.list ]; then
+      if [ -f /etc/apt/keyrings/bigbluebutton-ubuntu-support.gpg]; then
+        rm -r /etc/apt/keyrings/bigbluebutton-ubuntu-support.gpg
+      fi
+      curl -fsSL "https://ppa.launchpadcontent.net/bigbluebutton/support/ubuntu/dists/jammy/Release.gpg" -o /etc/apt/keyrings/bigbluebutton-ubuntu-support-release.gpg
+      curl -sL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2E1B01D0E95B94BC' | gpg --dearmor > /etc/apt/keyrings/bigbluebutton-ubuntu-support.gpg
+      rm -r /etc/apt/keyrings/bigbluebutton-ubuntu-support-release.gpg 
+      echo "deb [signed-by=/etc/apt/keyrings/bigbluebutton-ubuntu-support.gpg] https://ppa.launchpadcontent.net/bigbluebutton/support/ubuntu/ jammy main" > /etc/apt/sources.list.d/bigbluebutton-ubuntu-support-jammy.list
+    fi
+    #BigBlueButton matin mainz coturn
+    if [ -f /etc/apt/sources.list.d/martin-uni-mainz-ubuntu-coturn-jammy.list ] &&  grep -q 18 /etc/apt/sources.list.d/bigbluebutton-ubuntu-support-jammy.list; then
+      sudo rm -r /etc/apt/sources.list.d/martin-uni-mainz-ubuntu-coturn-jammy.list
+    fi
+    if [ ! -f /etc/apt/sources.list.d/martin-uni-mainz-ubuntu-coturn-jammy.list ]; then
+      if [ -f /etc/apt/keyrings/bigbluebutton-ubuntu-support-release.gpg ]; then
+        rm -r /etc/apt/keyrings/martin-uni-mainz-ubuntu-coturn.gpg 
+      fi
+      curl  https://ppa.launchpadcontent.net/martin-uni-mainz/coturn/ubuntu/dists/jammy/Release.gpg -o /etc/apt/keyrings/Release.gpg
+      curl -sL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x4B77C2225D3BBDB3' | gpg --dearmor > /etc/apt/keyrings/martin-uni-mainz-ubuntu-coturn.gpg
+      rm -r /etc/apt/keyrings/Release.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/martin-uni-mainz-ubuntu-coturn.gpg] https://ppa.launchpadcontent.net/martin-uni-mainz/coturn/ubuntu/ jammy main" > /etc/apt/sources.list.d/martin-uni-mainz-ubuntu-coturn-jammy.list
+    fi
 
     if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
       # Node 18 might be installed, previously used in BigBlueButton
@@ -297,9 +333,8 @@ main() {
       sudo rm -r /etc/apt/sources.list.d/nodesource.list
     fi
     if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
-      sudo mkdir -p /etc/apt/keyrings
       if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
-        rm /etc/apt/keyrings/nodesource.gpg
+        rm -r /etc/apt/keyrings/nodesource.gpg 
       fi
       curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
       NODE_MAJOR=22
@@ -307,9 +342,9 @@ main() {
     fi
 
     # postgres for BigBlueButton core
-    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-    if [ ! -f /etc/apt/trusted.gpg.d/postgresql.gpg ]; then
-      curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+    sudo sh -c 'echo "deb [signed-by=/etc/apt/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+    if [ ! -f /etc/apt/keyrings/postgresql.gpg ]; then
+      curl -fsSL "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | sudo gpg --dearmor -o /etc/apt/keyrings/postgresql.gpg
     fi
 
     touch /root/.rnd
@@ -320,6 +355,7 @@ main() {
 
     need_pkg openjdk-17-jre
     update-java-alternatives -s java-1.17.0-openjdk-amd64
+    chmod 644 /etc/apt/keyrings/* #make apt readable for apt
   fi
 
   apt-get update
@@ -1374,15 +1410,15 @@ install_docker() {
 
   # Install Docker
   if ! apt-key list | grep -q Docker; then
-    if [ ! -f /usr/share/keyrings/docker-archive-keyring.gpg ]; then
-      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    if [ ! -f /etc/apt/keyrings/docker-archive-keyring.gpg ]; then
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker-archive-keyring.gpg
     fi
   fi
   if ! dpkg -l | grep -q docker-ce; then
 
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
+    chmod 644 /etc/apt/keyrings/*
     apt-get update
     need_pkg docker-ce docker-ce-cli containerd.io
   fi

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -341,11 +341,6 @@ main() {
       echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
     fi
 
-    # postgres for BigBlueButton core
-    sudo sh -c 'echo "deb [signed-by=/etc/apt/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-    if [ ! -f /etc/apt/keyrings/postgresql.gpg ]; then
-      curl -fsSL "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | sudo gpg --dearmor -o /etc/apt/keyrings/postgresql.gpg
-    fi
 
     touch /root/.rnd
     install_docker		                     # needed for bbb-libreoffice-docker

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1442,6 +1442,22 @@ install_docker() {
 
     docker version > /dev/null || err "docker is failing to restart, something is wrong retry to resolve - exiting"
     say "docker is running!"
+    #Adds the proxy to docker  
+    if [ -f /etc/systemd/system/docker.service.d  ]; then
+        rm  -r  /etc/systemd/system/docker.service.d 
+    fi
+    if [ -f /etc/systemd/system/docker.service.d/http-proxy.conf  ]; then
+        rm  -r /etc/systemd/system/docker.service.d/http-proxy.conf  
+    fi
+    mkdir -p /etc/systemd/system/docker.service.d
+    touch /etc/systemd/system/docker.service.d/http-proxy.conf
+    echo '[Service]' > /etc/systemd/system/docker.service.d/http-proxy.conf
+    echo Environment="HTTP_PROXY="$HTTP_PROXY"" >> /etc/systemd/system/docker.service.d/http-proxy.conf
+    echo Environment="HTTPS_PROXY="$HTTP_PROXY"" >> /etc/systemd/system/docker.service.d/http-proxy.conf
+    systemctl daemon-reload
+    systemctl restart docker
+    docker version > /dev/null || err "docker is failing to restart, something is wrong retry to resolve - exiting"
+    say "docker is running with proxy!"
   fi
 
 }

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -352,7 +352,7 @@ main() {
     chmod 644 /etc/apt/keyrings/* #make apt readable for apt
   fi
 
-  apt-get update
+  apt upgrade -o Dpkg::Options::="--ignore-hold"
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
   need_pkg apt-transport-https haveged
@@ -573,7 +573,7 @@ need_pkg() {
   while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg lock"; sleep 1; done
 
   if [ ! "$SOURCES_FETCHED" = true ]; then
-    apt-get update
+    apt upgrade -o Dpkg::Options::="--ignore-hold"
     SOURCES_FETCHED=true
   fi
 
@@ -1413,7 +1413,7 @@ install_docker() {
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     chmod 644 /etc/apt/keyrings/*
-    apt-get update
+    apt upgrade -o Dpkg::Options::="--ignore-hold"
     need_pkg docker-ce docker-ce-cli containerd.io
   fi
   if ! which docker; then err "Docker did not install"; fi
@@ -1465,7 +1465,7 @@ install_ssl() {
   mkdir -p /etc/nginx/ssl
 
   if [ -z "$PROVIDED_CERTIFICATE" ]; then
-    apt-get update
+    apt upgrade -o Dpkg::Options::="--ignore-hold"
     need_pkg certbot
 
     if [[ -f "/etc/letsencrypt/live/$HOST/fullchain.pem" ]] && [[ -f "/etc/letsencrypt/renewal/$HOST.conf" ]] \
@@ -1793,7 +1793,7 @@ HERE
 
 
 install_coturn() {
-  apt-get update
+  apt upgrade -o Dpkg::Options::="--ignore-hold"
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
   need_pkg software-properties-common certbot

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -352,9 +352,10 @@ main() {
     chmod 644 /etc/apt/keyrings/* #make apt readable for apt
   fi
 
-  apt upgrade -o Dpkg::Options::="--ignore-hold"
-  apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
+  apt-get update
+  apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
+  
   need_pkg apt-transport-https haveged
   need_pkg bigbluebutton
   need_pkg bbb-html5
@@ -573,7 +574,7 @@ need_pkg() {
   while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do echo "Sleeping for 1 second because of dpkg lock"; sleep 1; done
 
   if [ ! "$SOURCES_FETCHED" = true ]; then
-    apt upgrade -o Dpkg::Options::="--ignore-hold"
+    apt-get update
     SOURCES_FETCHED=true
   fi
 
@@ -1413,7 +1414,7 @@ install_docker() {
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     chmod 644 /etc/apt/keyrings/*
-    apt upgrade -o Dpkg::Options::="--ignore-hold"
+    apt-get update
     need_pkg docker-ce docker-ce-cli containerd.io
   fi
   if ! which docker; then err "Docker did not install"; fi
@@ -1465,7 +1466,7 @@ install_ssl() {
   mkdir -p /etc/nginx/ssl
 
   if [ -z "$PROVIDED_CERTIFICATE" ]; then
-    apt upgrade -o Dpkg::Options::="--ignore-hold"
+    apt-get update
     need_pkg certbot
 
     if [[ -f "/etc/letsencrypt/live/$HOST/fullchain.pem" ]] && [[ -f "/etc/letsencrypt/renewal/$HOST.conf" ]] \
@@ -1793,7 +1794,7 @@ HERE
 
 
 install_coturn() {
-  apt upgrade -o Dpkg::Options::="--ignore-hold"
+  apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
   need_pkg software-properties-common certbot


### PR DESCRIPTION
I had several error with apt-key such that i couldn't install bbb.

Changed all keys to go to /etc/apt/keyrings/

