### PR TITLE
Use the version of postrgresql that comes with Ubuntu 22.04 (14)

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -306,12 +306,6 @@ main() {
       echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
     fi
 
-    # postgres for BigBlueButton core
-    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-    if [ ! -f /etc/apt/trusted.gpg.d/postgresql.gpg ]; then
-      curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-    fi
-
     touch /root/.rnd
     install_docker		                     # needed for bbb-libreoffice-docker
     need_pkg ruby


### PR DESCRIPTION
We have decided to stick to the version of `postgresql` that goes with Ubuntu 22.04 (postgresql-14) instead of adding the .list in bbb-install.sh. The main reason - challenges being able to predict which major version of postgres we end up with after re-running bbb-install.sh [and inability to override configs without knowing the version].
Check https://github.com/bigbluebutton/bigbluebutton/pull/21629 for more info.