### PR TITLE
Disable nginx default site

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1680,6 +1680,13 @@ fi
   yq e -i '.mediasoup.plainRtp.listenIp.ip = "0.0.0.0"' $TARGET
   yq e -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
 
+  # nginx package enables default website which collides with bigbluebutton config
+  # check if the default website is enabled (symlink present) parallel to bigbluebutton
+  # being enabled and if so, remove the symlink | fixes https://github.com/bigbluebutton/bbb-install/issues/780
+  DEFAULT_SITE=/etc/nginx/sites-enabled/default
+  BBB_SITE=/etc/nginx/sites-enabled/bigbluebutton
+  [ -L $DEFAULT_SITE ] && [ -L $BBB_SITE ] && rm $DEFAULT_SITE
+
   systemctl reload nginx
 }
 


### PR DESCRIPTION
Avoid possible collision with bigbluebutton site by removing the symlink. Fixes #780.