### PR TITLE
WIP: preparing to support Ubuntu 24.04 in BBB 4.0

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -23,30 +23,30 @@
 #
 #  Examples
 #
-#  Install BigBlueButton 3.0.x with a SSL certificate from Let's Encrypt using hostname bbb.example.com
+#  Install BigBlueButton 4.0.x with a SSL certificate from Let's Encrypt using hostname bbb.example.com
 #  and email address info@example.com and apply a basic firewall
 #
-#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release/bbb-install.sh | bash -s -- -w -v jammy-300 -s bbb.example.com -e info@example.com
+#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -w -v noble-400 -s bbb.example.com -e info@example.com
 #
 #  Install BigBlueButton with SSL + Greenlight
 #
-#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release/bbb-install.sh  | bash -s -- -w -v jammy-300 -s bbb.example.com -e info@example.com -g
+#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh  | bash -s -- -w -v noble-400 -s bbb.example.com -e info@example.com -g
 #
 
 usage() {
     set +x
     cat 1>&2 <<HERE
 
-Script for installing a BigBlueButton 3.0 server in under 30 minutes.
+Script for installing a BigBlueButton 4.0 server in under 30 minutes.
 
 This script also checks if your server supports https://docs.bigbluebutton.org/administration/install/#minimum-server-requirements
 
 USAGE:
-    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release/bbb-install.sh | bash -s -- [OPTIONS]
+    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- [OPTIONS]
 
 OPTIONS (install BigBlueButton):
 
-  -v <version>           Install given version of BigBlueButton (e.g. 'jammy-300') (required)
+  -v <version>           Install given version of BigBlueButton (e.g. 'noble-400') (required)
 
   -s <hostname>          Configure server with <hostname>
   -e <email>             Email for Let's Encrypt certbot
@@ -98,17 +98,17 @@ VARIABLES (configure Greenlight only):
 
 EXAMPLES:
 
-Sample options for setup a BigBlueButton 3.0 server
+Sample options for setup a BigBlueButton 4.0 server
 
-    -v jammy-300 -s bbb.example.com -e info@example.com
+    -v noble-400 -s bbb.example.com -e info@example.com
 
-Sample options for setup a BigBlueButton 3.0 server with Greenlight 3 and optionally Keycloak
+Sample options for setup a BigBlueButton 4.0 server with Greenlight 3 and optionally Keycloak
 
-    -v jammy-300 -s bbb.example.com -e info@example.com -g [-k]
+    -v noble-400 -s bbb.example.com -e info@example.com -g [-k]
 
-Sample options for setup a BigBlueButton 3.0 server with LTI framework while managing LTI consumer credentials MY_KEY:MY_SECRET
+Sample options for setup a BigBlueButton 4.0 server with LTI framework while managing LTI consumer credentials MY_KEY:MY_SECRET
 
-    -v jammy-300 -s bbb.example.com -e info@example.com -t MY_KEY:MY_SECRET
+    -v noble-400 -s bbb.example.com -e info@example.com -t MY_KEY:MY_SECRET
 
 SUPPORT:
     Community: https://bigbluebutton.org/support
@@ -250,7 +250,7 @@ main() {
   # Check if we're installing coturn (need an e-mail address for Let's Encrypt)
   if [ -z "$VERSION" ] && [ -n "$COTURN" ]; then
     if [ -z "$EMAIL" ]; then err "Installing coturn needs an e-mail address for Let's Encrypt"; fi
-    check_ubuntu 22.04
+    check_ubuntu 24.04
 
     install_coturn
     exit 0
@@ -277,15 +277,13 @@ main() {
   # need_pkg xmlstarlet
   get_IP "$HOST"
 
-  if [ "$DISTRO" == "jammy" ]; then
+  if [ "$DISTRO" == "noble" ]; then
     need_pkg ca-certificates
 
-    need_ppa rmescandon-ubuntu-yq-jammy.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
+    need_ppa rmescandon-ubuntu-yq-noble.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
     #need_ppa ppa:rmescandon/yq
     need_pkg yq
     yq --version
-
-    #need_ppa libreoffice-ubuntu-ppa-jammy.list       ppa:libreoffice/ppa        1378B444 # Latest version of libreoffice
 
     need_ppa bigbluebutton-ubuntu-support-focal.list ppa:bigbluebutton/support  2E1B01D0E95B94BC    # Needed for libopusenc0
     need_ppa martin-uni-mainz-ubuntu-coturn-focal.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
@@ -562,7 +560,7 @@ need_ppa() {
 }
 
 check_version() {
-  if ! echo "$1" | grep -Eq "jammy-30"; then err "This script can only install BigBlueButton 3.0 and is meant to be run on Ubuntu 22.04 (jammy) server."; fi
+  if ! echo "$1" | grep -Eq "noble-40"; then err "This script can only install BigBlueButton 4.0 and is meant to be run on Ubuntu 24.04 (noble) server."; fi
   DISTRO=${1%%-*}
   if ! wget -qS --spider "https://$PACKAGE_REPOSITORY/$1/dists/bigbluebutton-$DISTRO/Release.gpg" > /dev/null 2>&1; then
     err "Unable to locate packages for $1 at $PACKAGE_REPOSITORY."


### PR DESCRIPTION
Part of https://github.com/bigbluebutton/bigbluebutton/pull/22883


---

At the time of writing this there is no plan yet about the name of the version of BigBlueButton after 3.1, nor timeline.
I am working on Ubuntu 24.04 support as one of the wish-list items for the near future. An item which is disruptive enough to be best done as early as possible in the development cycle.