### PR TITLE
Fix issue #789

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -343,6 +343,10 @@ main() {
     install_ssl
   fi
 
+  if [ -n "$UFW" ]; then
+    setup_ufw 
+  fi
+
   if [ -n "$COTURN" ]; then
     configure_coturn
 
@@ -358,19 +362,31 @@ main() {
     # so if NAT is in use, add an iptables rule to adjust the destination IP address
     # of UDP packets sent from the turn server to FreeSWITCH.
     if [ -n "$INTERNAL_IP" ]; then
-      need_pkg iptables-persistent
-      iptables -t nat -A OUTPUT -p udp -s "$INTERNAL_IP" -d "$IP" -j DNAT --to-destination "$INTERNAL_IP"
-      netfilter-persistent save
+      # Due to Ubuntu 22.04 bug #1987227 you can't use UFW and iptables-persistent
+      # Ubuntu will be stripped of network connectivity after reboot
+      # If UFW is being installed, use UFW
+      if [ -n "$UFW" ]; then
+      # Define the NAT rule to be added
+      RULE="-A OUTPUT -p udp -s $INTERNAL_IP -d $IP -j DNAT --to-destination $INTERNAL_IP"
+      # Check if the rule already exists in /etc/ufw/before.rules to avoid duplicates
+        if ! grep -qF "$RULE" /etc/ufw/before.rules; then
+          # Insert the rule into the *nat section before the COMMIT line
+          sed -i '/^*nat/,/^COMMIT$/ {/^COMMIT$/i '"$RULE"' }' /etc/ufw/before.rules
+          # Reload UFW to apply the changes immediately
+          ufw reload
+        fi
+      # If UFW is not being installed, use iptables-persistent
+      else
+        need_pkg iptables-persistent
+        iptables -t nat -A OUTPUT -p udp -s "$INTERNAL_IP" -d "$IP" -j DNAT --to-destination "$INTERNAL_IP"
+        netfilter-persistent save
+      fi
     fi
   fi
 
   apt-get auto-remove -y
 
   systemctl restart systemd-journald
-
-  if [ -n "$UFW" ]; then
-    setup_ufw 
-  fi
 
   if [ -n "$HOST" ]; then
     bbb-conf --setip "$HOST"
@@ -1845,4 +1861,3 @@ HERE
 }
 
 main "$@" || exit 1
-


### PR DESCRIPTION
There is a conflict between UFW and iptables-persistent / netfilter-persistent, due to a known bug in Ubuntu 22.04 https://bugs.launchpad.net/ufw/+bug/1987227 After reboot with UFW enabled, the network connectivity breaks because every single package is dropped. I was able to circumvent this Ubuntu bug by modifying BBB installation script so that iptables-persistent is only being installed if UFW is NOT being installed. If UFW is being installed, I'm trying to mimic iptables-persistent functionality with UFW.