### PR TITLE
Update ImageMagick policy to allow the XC module

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -498,6 +498,7 @@ main() {
   <policy domain="module" rights="none" pattern="*" />
   <policy domain="module" rights="read | write" pattern="{BMP,GIF,JPEG,PDF,PNG,TIFF,WEBP}"/>
   <policy domain="module" rights="read | write" pattern="{MPC}" stealth="true"/>
+  <policy domain="module" rights="read" pattern="{XC}"/>
   <policy domain="module" rights="write" pattern="{JSON,INFO,PNM,PS,SVG}"/>
   <!-- This policy sets the number of times to replace content of certain
        memory buffers and temporary files before they are freed or deleted. -->


### PR DESCRIPTION
The presentation format recording scripts use the ImageMagick XC module (which stands for "Constant Color") to generate placeholder images for slides which are missing / failed to convert and a few other circumstances.

The XC module is safe to enable, since it doesn't involve reading any files - it only generates single-color in memory images, and image sizes (memory usage) are limited by other sections of the policy.

Fix proposed by @schrd in https://github.com/bigbluebutton/bigbluebutton/issues/24352#issuecomment-3636674056

Fixes https://github.com/bigbluebutton/bigbluebutton/issues/24352