### PR TITLE
Increase image width and height limits to 5KP

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -463,10 +463,10 @@ main() {
   <policy domain="resource" name="list-length" value="16"/>
   <!-- Set the maximum width of an image.  When this limit is exceeded, an
        exception is thrown. -->
-  <policy domain="resource" name="width" value="4KP"/>
+  <policy domain="resource" name="width" value="5KP"/>
   <!-- Set the maximum height of an image.  When this limit is exceeded, an
        exception is thrown. -->
-  <policy domain="resource" name="height" value="4KP"/>
+  <policy domain="resource" name="height" value="5KP"/>
   <!-- Periodically yield the CPU for at least the time specified in
        milliseconds. -->
   <policy domain="resource" name="throttle" value="2"/>


### PR DESCRIPTION
Otherwise 4K Images cannot be processed, like the BBB Summit 2024 Group Picture (4032 × 3024)

If the filesize is too big, no error is shown and a white image is displayed. 


**Sidenote for BBB-Team**
- Improve error handling in bbb-web (not just a blank image)
- Think about relationship between maxFileSizeUpload setting and the limits defined here