### PR TITLE
Prevent internal DNS routing issues when domain used as hostname

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -955,6 +955,18 @@ install_greenlight_v3(){
   # Preparing and checking the environment.
   say "preparing and checking the environment to install/update greenlight-v3..."
 
+  # Check for potential DNS resolution conflicts
+  # See https://github.com/bigbluebutton/greenlight/issues/6174
+  if grep -qE "^(127\.[0-9.]+\.[0-9]+\.[0-9]+|::1)[[:space:]]+.*$HOST" /etc/hosts; then
+    err "Hosts configuration issue detected: Your domain '$HOST' is mapped to a loopback address in /etc/hosts.
+    This is known to cause connectivity issues between Greenlight and the BigBlueButton API (see Greenlight issue #6174).
+    WARNING: This entry may be added automatically by cloud providers.
+    To fix this, you have two options:
+    1. Edit, comment or remove the affected line in /etc/hosts
+    2. Disable reading '/etc/hosts' by adding 'ReadEtcHosts=no' to '/etc/systemd/resolved.conf' and restart systemd-resolved
+    Please apply one of these workaround, then restart the installation script."
+  fi
+
   if [ ! -d $GL3_DIR ]; then
     mkdir -p $GL3_DIR && say "created $GL3_DIR"
   fi


### PR DESCRIPTION
This PR adds a validation step to ensure the server's `$HOST` is not mapped to a loopback address (e.g., 127.0.1.1 or 127.0.0.1) in `/etc/hosts`.

Problem solved :
Many cloud providers automatically add an entry to `/etc/hosts` mapping the hostname to `127.0.1.1`. 
When using a domain as hostname and installing BigBlueButton with Greenlight, this loopback mapping causes internal networking conflicts within Docker containers DNS resolution (due to systemd-resolved default configuration). The Greenlight containers attempt to resolve the BBB API locally instead of via the public IP, leading to 400 Bad Request errors when starting rooms.

Full details of the issue can be found here: 
https://github.com/bigbluebutton/greenlight/issues/6174

Many users have likely encountered this issue, often without realizing the cause, for instance: 
* https://github.com/bigbluebutton/greenlight/issues/5801
* https://github.com/bigbluebutton/greenlight/issues/5781
* https://github.com/bigbluebutton/greenlight/issues/5144#issuecomment-1567342320
* https://github.com/bigbluebutton/greenlight/issues/2018
* ...