### PR TITLE
fix: turn-stun-servers.xml gets overwritten in /etc/bigbluebutton

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1811,11 +1811,14 @@ fi
 }
 
 configure_coturn() {
-  TURN_XML=/etc/bigbluebutton/turn-stun-servers.xml
 
   if [ -z "$COTURN" ]; then
     # the user didn't pass '-c', so use the local TURN server's host
     COTURN_HOST=$HOST
+    TURN_XML=/usr/share/bbb-web/WEB-INF/classes/spring/turn-stun-servers.xml
+  elif [[ "$COTURN" ]]; then
+    # the user passed '-c' with 'host:secret'
+    TURN_XML=/etc/bigbluebutton/turn-stun-servers.xml
   fi
 
   cat <<HERE > $TURN_XML


### PR DESCRIPTION
This PR adjusts the TURN_XML logic:

Without -c parameter (no external TURN server): Uses the default template file `/usr/share/bbb-web/WEB-INF/classes/spring/turn-stun-servers.xml` for local TURN operation.

With -c parameter (external TURN server specified): Uses the override config file `/etc/bigbluebutton/turn-stun-servers.xml`.

This also fixes this issue: https://github.com/bigbluebutton/bigbluebutton/issues/24579