### PR TITLE
Support Ubuntu 24 in BBB 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Naming convention:
 
 Please use `bbb-install.sh` to install or upgrade BigBlueButton.
 
-For example use `bbb-install.sh` with the parameter `-v jammy-400` to install BigBlueButton 4.0 or upgrade to that release. Check https://docs.bigbluebutton.org for the latest production ready release of BigBlueButton.
+For example use `bbb-install.sh` with the parameter `-v noble-400` to install BigBlueButton 4.0 or upgrade to that release. Check https://docs.bigbluebutton.org for the latest production ready release of BigBlueButton.
 
 There are checks within the scripts that will inform you if the upgrade is not possible (i.e. operating system changed between the releases, or some really significant changes were made that prevent us from supporting an upgrade).
 etc.
@@ -19,17 +19,16 @@ To help you set up a new BigBlueButton server (or upgrade from an earlier versio
 The full source code for the installation scripts can be found [here](https://github.com/bigbluebutton/bbb-install).
 
 
-So, to install the latest iteration of BigBlueButton 4.0 on a new 64-bit Ubuntu 22.04 server with a public IP address, a hostname (such as `bbb.example.com`) that resolves to the public IP address, and an email address (such as `info@example.com`), log into your new server via SSH and run the following command as root.
+So, to install the latest iteration of BigBlueButton 4.0 on a new 64-bit Ubuntu 24.04 server with a public IP address, a hostname (such as `bbb.example.com`) that resolves to the public IP address, and an email address (such as `info@example.com`), log into your new server via SSH and run the following command as root.
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -w -v jammy-400 -s bbb.example.com -e info@example.com
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -w -v noble-400 -s bbb.example.com -e info@example.com
 ~~~
 
 This command pulls down the latest version of `bbb-install.sh` from BigBlueButton 4.0 branch , sends it to the Bash shell interpreter, and installs BigBlueButton using the parameters provided:
 
   * `-w` installs the uncomplicated firewall (UFW) to restrict access to TCP/IP ports 22, 80, and 443, and UDP ports in range 16384-32768.
-  * `-v jammy-400` installs the latest iteration of BigBlueButton 4.0.x .
-  * `-v jammy-300` installs the latest iteration of BigBlueButton 3.0.x .
+  * `-v noble-400` installs the latest iteration of BigBlueButton 4.0.x .
   * `-s` sets the server's hostname to be `bbb.example.com`.
   * `-e` provides an email address for Let's Encrypt to generate a valid SSL certificate for the host.
 
@@ -74,7 +73,7 @@ Note:
 
 There are many hosting companies that can provide you with dedicated virtual and bare-metal servers to run BigBlueButton.  We list a few popular choices below (we are not making any recommendation here, just listing some of the more popular choices).
 
-For quick setup, [Digital Ocean](https://www.digitalocean.com/) offers both virtual servers with Ubuntu 20.04 64-bit and a single public IP address (no firewall).  [Hetzner](https://hetzner.cloud/) offers dedicated servers with single IP address.
+For quick setup, [Digital Ocean](https://www.digitalocean.com/) offers both virtual servers with Ubuntu 24.04 64-bit and a single public IP address (no firewall).  [Hetzner](https://hetzner.cloud/) offers dedicated servers with single IP address.
 
 Other popular choices, such as [ScaleWay](https://www.scaleway.com/) (choose either Bare Metal or Pro servers) and [Google Compute Engine](https://cloud.google.com/compute/), offer servers that are set up behind network address translation (NAT).  That is, they have both an internal and external IP address.  When installing on these servers, the `bbb-install.sh` will detect the internal/external addresses and configure BigBlueButton accordingly.  
 
@@ -122,7 +121,7 @@ USAGE:
 
 OPTIONS (install BigBlueButton):
 
-  -v <version>           Install given version of BigBlueButton (e.g. 'jammy-400') (required)
+  -v <version>           Install given version of BigBlueButton (e.g. 'noble-400') (required)
 
   -s <hostname>          Configure server with <hostname>
   -e <email>             Email for Let's Encrypt certbot
@@ -176,15 +175,15 @@ EXAMPLES:
 
 Sample options for setup a BigBlueButton 4.0 server
 
-    -v jammy-400 -s bbb.example.com -e info@example.com
+    -v noble-400 -s bbb.example.com -e info@example.com
 
 Sample options for setup a BigBlueButton 4.0 server with Greenlight 3 and optionally Keycloak
 
-    -v jammy-400 -s bbb.example.com -e info@example.com -g [-k]
+    -v noble-400 -s bbb.example.com -e info@example.com -g [-k]
 
 Sample options for setup a BigBlueButton 4.0 server with LTI framework while managing LTI consumer credentials MY_KEY:MY_SECRET
 
-    -v jammy-400 -s bbb.example.com -e info@example.com -t MY_KEY:MY_SECRET
+    -v noble-400 -s bbb.example.com -e info@example.com -t MY_KEY:MY_SECRET
 
 SUPPORT:
     Community: https://bigbluebutton.org/support
@@ -206,7 +205,7 @@ Note: we're using `bbb.example.com` as an example hostname and `info@example.com
 With just these two pieces of information (FQDN and email address) you can use `bbb-install.sh` to automate the configuration of the BigBlueButton server with a TLS/SSL certificate.  For example, to install BigBlueButton with a TLS/SSL certificate from Let's Encrypt using `bbb.example.com` and `info@example.com`, enter the following command:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -221,7 +220,7 @@ The default installation is meant to be for servers that are publicly available.
 When installing BigBlueButton in a private network, it is possible to validate the FQDN manually, by adding the option `-x` to the command line. As in:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -x [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -x [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -289,7 +288,7 @@ More on Greenlight can be found [here](https://docs.bigbluebutton.org/greenlight
 To [install Greenlight](https://docs.bigbluebutton.org/greenlight/v3/install#bbb-install-script) you can simply use the `bbb-install.sh` command `-g` option:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -g [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -g [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -298,7 +297,7 @@ wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-rel
 To install Keycloak just use the `-k` option with `-g`:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -g -k [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -g -k [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -338,7 +337,7 @@ After installation, you can become an [administrator](https://docs.bigbluebutton
 Updating Greenlight is done simply through re-running the `bbb-install.sh` anytime while using the `-g` option:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -g [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -g [options]
 ~~~
 
 Note: You don't need to re-use the `-k` to update Keycloak if already installed, using `-g` updates both of Greenlight and Keycloak as the latter is considered as a dependency to the project. 
@@ -367,7 +366,7 @@ The Broker is a Web Application that acts as a LTI Broker for connecting Tool Co
 To install the LTI framework you can simply use the `bbb-install.sh` command `-t` option while providing a `KEY:SECRET` which you'll use when deploying the BigBlueButton LTI applications to your platform, for more details about the integration of a tool to your platform please refer to the official documentation of your solution:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -t MY_KEY:MY_SECRET [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -t MY_KEY:MY_SECRET [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -380,7 +379,7 @@ You can manage your LTI credentials through the `bbb-install.sh` command using t
 - To change the secret of a LTI credential re-run the same with the `-t` option while also using the same **KEY** but a new **SECRET**:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -t MY_KEY:MY_NEW_SECRET [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -t MY_KEY:MY_NEW_SECRET [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -391,7 +390,7 @@ This overwrites the old secret, so expect a discontinuity in your integration of
 - To add new credentials, re-run the same `bbb-install.sh` command with the `-t` option while also providing new pair of **KEY** and **SECRET**:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -t MY_NEW_KEY:MY_NEW_SECRET [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -t MY_NEW_KEY:MY_NEW_SECRET [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -411,7 +410,7 @@ Note: on your system `bbb.example.com` will be substituted with your FQDN.
 Updating the LTI framework is done simply through re-running the `bbb-install.sh` anytime while using the `-t` option and providing credentials:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -t KEY:SECRET [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -t KEY:SECRET [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -428,7 +427,7 @@ You can become a contributor also!
 The install script allows you to pass a path which will be used to create a symbolic link with `/var/bigbluebutton`:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -s bbb.example.com -e info@example.com -v jammy-400 -w -m /mnt/test [options]
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -s bbb.example.com -e info@example.com -v noble-400 -w -m /mnt/test [options]
 ~~~
 
 > [options] is a placeholder for one or more [options](#command-options) that you may use.
@@ -440,7 +439,7 @@ This allows users to store the contents of /`var/bigbluebutton`, which can get q
 If you want to set up BigBlueButton with a TLS/SSL certificate, [GreenLight](#install-greenlight), [Keycloak](https://docs.bigbluebutton.org/greenlight/v3/external-authentication#installing-keycloak) and [BigBlueButton LTI](#install-bigbluebutton-lti-framework) with LTI credentials `MY_KEY:MY_SECRET` , you can do this all with a single command:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -g -k -t MY_KEY:MY_SECRET
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -g -k -t MY_KEY:MY_SECRET
 ~~~
 
 Note: You'd need to substitute your FQDN, email address and LTI credentials.
@@ -455,7 +454,7 @@ Furthermore, you can re-run the same `bbb-install.sh` command used for installat
 So to update the system in [Doing everything with a single command](#doing-everything-with-a-single-command) example you'd re-run the same command with the same options:
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -w -g -k -t MY_KEY:MY_SECRET
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -w -g -k -t MY_KEY:MY_SECRET
 ~~~
 
 - `-g` will update Greenlight **and Keycloak** to the latest stable version.
@@ -505,7 +504,7 @@ wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-rel
 
 will do the following
 
-  * Install the latest version of coturn available for Ubuntu 22.04
+  * Install the latest version of coturn available for Ubuntu 24.04
     * Provide a minimal configuration for `/etc/turnserver.conf`
     * Add a systemd override to ensure coturn can bind to port 443
     * Configure logging to `/var/log/turnserver/turnserver.log`
@@ -518,7 +517,7 @@ With a SSL certificate in place, coturn can relay access to your BigBlueButton s
 After the TURN server is setup, you can configure your BigBlueButton server to use the TURN server by running the `bbb-install.sh` command again and add the parameter `-c <FQDN>:<SECRET>` (this tells `bbb-install.sh` to set up the configuration for the TURN server running at <FQDN> using the share secret <SECRET>.  For example,
 
 ~~~
-wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v jammy-400 -s bbb.example.com -e info@example.com -c turn.example.com:1234abcd
+wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -v noble-400 -s bbb.example.com -e info@example.com -c turn.example.com:1234abcd
 ~~~
 
 You can re-use a single TURN server for multiple BigBlueButton installations.

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1979,9 +1979,14 @@ KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-grou
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
 HERE
 
-  # Validate before applying
+  # Validate config before applying (binary is still sshd)
   if sshd -t; then
-    systemctl restart sshd
+    # Ubuntu 24.04 uses ssh.service, older Ubuntu used sshd.service
+    if systemctl is-active --quiet ssh 2>/dev/null; then
+      systemctl restart ssh
+    else
+      systemctl restart sshd
+    fi
     say "SSH hardening applied successfully"
   else
     say "SSH config validation failed - removing hardening file"

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -281,7 +281,6 @@ main() {
 
   if [ "$DISTRO" != "noble" ]; then
     err "This version of BigBlueButton requires Ubuntu 24.04"
-    exit 0
   fi
 
   get_IP "$HOST"

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1964,7 +1964,7 @@ harden_ssh() {
 
   local SSH_HARDENING_FILE="/etc/ssh/sshd_config.d/99-hardened-ciphers.conf"
 
-  # Check if sshd_config includes the .d directory (Ubuntu 22.04 does by default)
+  # Check if sshd_config includes the .d directory (Ubuntu 24.04 does by default)
   if ! grep -q "^Include.*/etc/ssh/sshd_config.d/" /etc/ssh/sshd_config; then
     say "Warning: /etc/ssh/sshd_config doesn't include sshd_config.d - adding include directive"
     echo "Include /etc/ssh/sshd_config.d/*.conf" >> /etc/ssh/sshd_config

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -26,11 +26,11 @@
 #  Install BigBlueButton 4.0.x with a SSL certificate from Let's Encrypt using hostname bbb.example.com
 #  and email address info@example.com and apply a basic firewall
 #
-#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -w -v jammy-400 -s bbb.example.com -e info@example.com
+#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh | bash -s -- -w -v noble-400 -s bbb.example.com -e info@example.com
 #
 #  Install BigBlueButton with SSL + Greenlight
 #
-#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh  | bash -s -- -w -v jammy-400 -s bbb.example.com -e info@example.com -g
+#    wget -qO- https://raw.githubusercontent.com/bigbluebutton/bbb-install/v4.0.x-release/bbb-install.sh  | bash -s -- -w -v noble-400 -s bbb.example.com -e info@example.com -g
 #
 
 usage() {
@@ -46,7 +46,7 @@ USAGE:
 
 OPTIONS (install BigBlueButton):
 
-  -v <version>           Install given version of BigBlueButton (e.g. 'jammy-400') (required)
+  -v <version>           Install given version of BigBlueButton (e.g. 'noble-400') (required)
 
   -s <hostname>          Configure server with <hostname>
   -e <email>             Email for Let's Encrypt certbot
@@ -101,15 +101,15 @@ EXAMPLES:
 
 Sample options for setup a BigBlueButton 4.0 server
 
-    -v jammy-400 -s bbb.example.com -e info@example.com
+    -v noble-400 -s bbb.example.com -e info@example.com
 
 Sample options for setup a BigBlueButton 4.0 server with Greenlight 3 and optionally Keycloak
 
-    -v jammy-400 -s bbb.example.com -e info@example.com -g [-k]
+    -v noble-400 -s bbb.example.com -e info@example.com -g [-k]
 
 Sample options for setup a BigBlueButton 4.0 server with LTI framework while managing LTI consumer credentials MY_KEY:MY_SECRET
 
-    -v jammy-400 -s bbb.example.com -e info@example.com -t MY_KEY:MY_SECRET
+    -v noble-400 -s bbb.example.com -e info@example.com -t MY_KEY:MY_SECRET
 
 SUPPORT:
     Community: https://bigbluebutton.org/support
@@ -256,7 +256,7 @@ main() {
   # Check if we're installing coturn (need an e-mail address for Let's Encrypt)
   if [ -z "$VERSION" ] && [ -n "$COTURN" ]; then
     if [ -z "$EMAIL" ]; then err "Installing coturn needs an e-mail address for Let's Encrypt"; fi
-    check_ubuntu 22.04
+    check_ubuntu 24.04
 
     install_coturn
     exit 0
@@ -278,56 +278,39 @@ main() {
   check_cpus
   check_ipv6
 
-  need_pkg wget curl gpg-agent dirmngr apparmor-utils
 
-  # need_pkg xmlstarlet
+  if [ "$DISTRO" != "noble" ]; then
+    err "This version of BigBlueButton requires Ubuntu 24.04"
+    exit 0
+  fi
+
   get_IP "$HOST"
 
-  if [ "$DISTRO" == "jammy" ]; then
-    need_pkg ca-certificates
 
-    need_ppa rmescandon-ubuntu-yq-jammy.list         ppa:rmescandon/yq          CC86BB64 # Edit yaml files with yq
-    #need_ppa ppa:rmescandon/yq
-    need_pkg yq
-    yq --version
+  need_pkg wget curl gpg-agent dirmngr apparmor-utils ca-certificates yq ruby apt-transport-https haveged openjdk-17-jre dnsutils
+  #need_ppa martin-uni-mainz-ubuntu-coturn-noble.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
 
-    #need_ppa libreoffice-ubuntu-ppa-jammy.list       ppa:libreoffice/ppa        1378B444 # Latest version of libreoffice
-
-    need_ppa bigbluebutton-ubuntu-support-jammy.list ppa:bigbluebutton/support  2E1B01D0E95B94BC    # Needed for libopusenc0
-    need_ppa martin-uni-mainz-ubuntu-coturn-jammy.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
-
-    if [ -f /etc/apt/sources.list.d/nodesource.list ] &&  grep -q 18 /etc/apt/sources.list.d/nodesource.list; then
-      # Node 18 might be installed, previously used in BigBlueButton
-      # Remove the repository config. This will cause the repository to get
-      # re-added using the current nodejs version, and nodejs will be upgraded.
-      sudo rm -r /etc/apt/sources.list.d/nodesource.list
+  if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
+    sudo mkdir -p /etc/apt/keyrings
+    if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
+      rm /etc/apt/keyrings/nodesource.gpg
     fi
-    if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
-      sudo mkdir -p /etc/apt/keyrings
-      if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
-        rm /etc/apt/keyrings/nodesource.gpg
-      fi
-      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-      NODE_MAJOR=22
-      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-    fi
-
-    touch /root/.rnd
-    install_docker		                     # needed for bbb-libreoffice-docker
-    need_pkg ruby
-
-    BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties            # Override file for local settings
-
-    need_pkg openjdk-17-jre
-    update-java-alternatives -s java-1.17.0-openjdk-amd64
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    NODE_MAJOR=22
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
   fi
+
+  touch /root/.rnd
+  install_docker		                     # needed for bbb-libreoffice-docker
+
+  BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties            # Override file for local settings
+
+  update-java-alternatives -s java-1.17.0-openjdk-amd64
 
   apt-get update
   apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" dist-upgrade
 
-  need_pkg apt-transport-https haveged
   need_pkg bigbluebutton
-  need_pkg bbb-html5
 
   if [ -f /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties ]; then
     SERVLET_DIR=/usr/share/bbb-web
@@ -693,20 +676,18 @@ need_ppa() {
 }
 
 check_version() {
-  if ! echo "$1" | grep -Eq "jammy-40"; then err "This script can only install BigBlueButton 4.0 and is meant to be run on Ubuntu 22.04 (jammy) server."; fi
+  if ! echo "$1" | grep -Eq "noble-4"; then err "This script can only install BigBlueButton 4.0 and is meant to be run on Ubuntu 24.04 (noble) server."; fi
   DISTRO=${1%%-*}
   if ! wget -qS --spider "https://$PACKAGE_REPOSITORY/$1/dists/bigbluebutton-$DISTRO/Release.gpg" > /dev/null 2>&1; then
     err "Unable to locate packages for $1 at $PACKAGE_REPOSITORY."
   fi
   check_root
-  need_pkg curl apt-transport-https
   curl -fsSL "https://$PACKAGE_REPOSITORY/repo/bigbluebutton.asc" | sudo tee /etc/apt/keyrings/bigbluebutton.asc
   echo "deb [signed-by=/etc/apt/keyrings/bigbluebutton.asc] https://$PACKAGE_REPOSITORY/$VERSION bigbluebutton-$DISTRO main" > /etc/apt/sources.list.d/bigbluebutton.list
 }
 
 check_host() {
   if [ -z "$PROVIDED_CERTIFICATE" ] && [ -z "$HOST" ]; then
-    need_pkg dnsutils apt-transport-https
     DIG_IP=$(dig +short "$1" | grep '^[.0-9]*$' | tail -n1)
     if [ -z "$DIG_IP" ]; then err "Unable to resolve $1 to an IP address using DNS lookup.";  fi
     get_IP "$1"
@@ -1755,21 +1736,18 @@ fi
 
   # shellcheck disable=SC1091
   eval "$(source /etc/bigbluebutton/bigbluebutton-release && declare -p BIGBLUEBUTTON_RELEASE)"
-  if [[ $BIGBLUEBUTTON_RELEASE == 2.2.* ]] && [[ ${BIGBLUEBUTTON_RELEASE#*.*.} -lt 29 ]]; then
-    sed -i "s/proxy_pass .*/proxy_pass https:\/\/$IP:7443;/g" /usr/share/bigbluebutton/nginx/sip.nginx
-  else
-    # Use nginx as proxy for WSS -> WS (see https://github.com/bigbluebutton/bigbluebutton/issues/9667)
-    yq e -i '.public.media.sipjsHackViaWs = true' /etc/bigbluebutton/bbb-html5.yml
-    sed -i "s/proxy_pass .*/proxy_pass http:\/\/$IP:5066;/g" /usr/share/bigbluebutton/nginx/sip.nginx
-    xmlstarlet edit --inplace --update '//param[@name="ws-binding"]/@value' --value "$IP:5066" /opt/freeswitch/conf/sip_profiles/external.xml
-  fi
+  # Use nginx as proxy for WSS -> WS (see https://github.com/bigbluebutton/bigbluebutton/issues/9667)
+  if [ ! -s /etc/bigbluebutton/bbb-html5.yml ]; then echo '{}' > /etc/bigbluebutton/bbb-html5.yml; fi
+  yq -y -i '.public.media.sipjsHackViaWs = true' /etc/bigbluebutton/bbb-html5.yml
+  sed -i "s/proxy_pass .*/proxy_pass http:\/\/$IP:5066;/g" /usr/share/bigbluebutton/nginx/sip.nginx
+  xmlstarlet edit --inplace --update '//param[@name="ws-binding"]/@value' --value "$IP:5066" /opt/freeswitch/conf/sip_profiles/external.xml
 
   sed -i 's/^bigbluebutton.web.serverURL=http:/bigbluebutton.web.serverURL=https:/g' "$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"
   if [ -f "$BBB_WEB_ETC_CONFIG" ]; then
     sed -i 's/^bigbluebutton.web.serverURL=http:/bigbluebutton.web.serverURL=https:/g' "$BBB_WEB_ETC_CONFIG"
   fi
 
-  yq e -i '.playback_protocol = "https"' /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
+  yq -y -i '.playback_protocol = "https"' /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
   chmod 644 /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
 
   # Update Greenlight (if installed) to use SSL
@@ -1791,29 +1769,29 @@ fi
   TARGET=/etc/bigbluebutton/bbb-webrtc-sfu/production.yml
   touch $TARGET
 
-  yq e -i ".freeswitch.ip = \"$IP\"" $TARGET
+  yq -y -i ".freeswitch.ip = \"$IP\"" $TARGET
 
   if [[ $BIGBLUEBUTTON_RELEASE == 2.2.* ]] && [[ ${BIGBLUEBUTTON_RELEASE#*.*.} -lt 29 ]]; then
     if [ -n "$INTERNAL_IP" ]; then
-      yq e -i ".freeswitch.sip_ip = \"$INTERNAL_IP\"" $TARGET
+      yq -y -i ".freeswitch.sip_ip = \"$INTERNAL_IP\"" $TARGET
     else
-      yq e -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
+      yq -y -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
     fi
   else
     # Use nginx as proxy for WSS -> WS (see https://github.com/bigbluebutton/bigbluebutton/issues/9667)
-    yq e -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
+    yq -y -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
   fi
   chown bigbluebutton:bigbluebutton $TARGET
   chmod 644 $TARGET
 
   # Configure mediasoup IPs, reference: https://raw.githubusercontent.com/bigbluebutton/bbb-webrtc-sfu/v2.7.2/docs/mediasoup.md
   # mediasoup IPs: WebRTC
-  yq e -i '.mediasoup.webrtc.listenIps[0].ip = "0.0.0.0"' $TARGET
-  yq e -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
+  yq -y -i '.mediasoup.webrtc.listenIps[0].ip = "0.0.0.0"' $TARGET
+  yq -y -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
 
   # mediasoup IPs: plain RTP (internal comms, FS <-> mediasoup)
-  yq e -i '.mediasoup.plainRtp.listenIp.ip = "0.0.0.0"' $TARGET
-  yq e -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
+  yq -y -i '.mediasoup.plainRtp.listenIp.ip = "0.0.0.0"' $TARGET
+  yq -y -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
 
   systemctl reload nginx
 }


### PR DESCRIPTION
BBB PR: https://github.com/bigbluebutton/bigbluebutton/pull/24805
bbb-docker-build-packages PR: https://github.com/bigbluebutton/bbb-docker-build-packages/pull/18

~~Includes #821~~

Changes of interest (i.e. other than renaming):
1. I combined a bunch of the `need_pkg` commands into one as they all seemed inevitable to be hit. Each would run apt update, so likely outcome is reduced time to install
2. no longer installing `yq` from `ppa:rmescandon/yq` but relying on noble's default "kislyuk" `yq` which comes with different syntax, hence the adjustments in all `yq` uses.
3. Dropped `ppa:bigbluebutton/support` `libopusenc0` as no longer needed
4. Commented out `ppa:martin-uni-mainz/coturn` `coturn` as likely no longer needed?! (it was a jammy version only either way)
5. No longer installing explicitly `bbb-html5` as we rely on the target.
6.  In the HTTPS / sip.nginx configuration logic, the outer `if [[ $BIGBLUEBUTTON_RELEASE == 2.2.* ]] && [[ … -lt 29 ]]` wrapper (which pointed sip.nginx at `https://$IP:7443`) was deleted, and the modern path is now unconditional: `sipjsHackViaWs = true`, `proxy_pass http://$IP:5066`, and the xmlstarlet edit to FreeSWITCH `external.xml` `ws-binding`.


