### PR TITLE
refactor: remove SIP.js-associated code

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -1747,7 +1747,6 @@ HERE
 fi
 
   # Configure rest of BigBlueButton Configuration for SSL
-  xmlstarlet edit --inplace --update '//param[@name="wss-binding"]/@value' --value "$IP:7443" /opt/freeswitch/conf/sip_profiles/external.xml
 
   # shellcheck disable=SC1091
   eval "$(source /etc/bigbluebutton/bigbluebutton-release && declare -p BIGBLUEBUTTON_RELEASE)"

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -792,7 +792,6 @@ check_nat() {
     xmlstarlet edit --inplace --update '//param[@name="ext-rtp-ip"]/@value' --value "\$\${external_rtp_ip}" /opt/freeswitch/conf/sip_profiles/external.xml
     xmlstarlet edit --inplace --update '//param[@name="ext-sip-ip"]/@value' --value "\$\${external_sip_ip}" /opt/freeswitch/conf/sip_profiles/external.xml
 
-    sed -i "s/$INTERNAL_IP:/$IP:/g" /usr/share/bigbluebutton/nginx/sip.nginx
     ip addr add "$IP" dev lo
 
     # If dummy NIC is not in dummy-nic.service (or the file does not exist), update/create it
@@ -1752,10 +1751,6 @@ fi
 
   # shellcheck disable=SC1091
   eval "$(source /etc/bigbluebutton/bigbluebutton-release && declare -p BIGBLUEBUTTON_RELEASE)"
-  # Use nginx as proxy for WSS -> WS (see https://github.com/bigbluebutton/bigbluebutton/issues/9667)
-  if [ ! -s /etc/bigbluebutton/bbb-html5.yml ]; then echo '{}' > /etc/bigbluebutton/bbb-html5.yml; fi
-  yq -y -i '.public.media.sipjsHackViaWs = true' /etc/bigbluebutton/bbb-html5.yml
-  sed -i "s/proxy_pass .*/proxy_pass http:\/\/$IP:5066;/g" /usr/share/bigbluebutton/nginx/sip.nginx
   xmlstarlet edit --inplace --update '//param[@name="ws-binding"]/@value' --value "$IP:5066" /opt/freeswitch/conf/sip_profiles/external.xml
 
   sed -i 's/^bigbluebutton.web.serverURL=http:/bigbluebutton.web.serverURL=https:/g' "$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"


### PR DESCRIPTION
See https://github.com/bigbluebutton/bigbluebutton/pull/25237, https://github.com/bigbluebutton/bigbluebutton/issues/20852.

- [refactor: stop provisioning the SIP.js audio bridge](https://github.com/bigbluebutton/bbb-install/commit/43f68dcb467eeb64cafe21bab36bbf946c98c86c) 
  - The SIP.js audio bridge is removed from BigBlueButton in favor of the
mediasoup (fullaudio) and LiveKit bridges, so the installer no longer
configures it. Drop the sip.nginx proxy_pass/IP rewrites as the
bbb-html5 package no longer ships sip.nginx, as well as the the
sipjsHackViaWs client override.
- [refactor: drop unused FreeSWITCH wss-binding:7443](https://github.com/bigbluebutton/bbb-install/commit/c89fcb5462162fc186e827c8cf51b75214de201e) 
  - The FreeSWITCH wss-binding (:7443) secure SIP-over-WebSocket listener
was reached only by the removed browser SIP.js bridge via the nginx
/ws proxy. bbb-webrtc-sfu connects over :5066 *only&, so bbb-install
no longer needs to set wss-binding.