### PR TITLE
refactor: Replace yq with bbb-yq-go (based on debian yq-go)

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -302,9 +302,9 @@ main() {
 
   get_IP "$HOST"
 
-
-  need_pkg wget curl gpg-agent dirmngr apparmor-utils ca-certificates yq ruby apt-transport-https haveged openjdk-17-jre dnsutils
   #need_ppa martin-uni-mainz-ubuntu-coturn-noble.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
+  need_ppa martin-uni-mainz-ubuntu-yq-go-noble.list ppa:martin-uni-mainz/yq-go 4B77C2225D3BBDB3 # Edit yaml files with debian's yq-go (mikefarah/yq syntax BBB 3.0 used rather than kislyuk syntax used by the yq tool included in Ubuntu 24.04)
+  need_pkg wget curl gpg-agent dirmngr apparmor-utils ca-certificates ruby apt-transport-https haveged openjdk-17-jre dnsutils yq-go
 
   if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
     sudo mkdir -p /etc/apt/keyrings
@@ -1757,7 +1757,7 @@ fi
     sed -i 's/^bigbluebutton.web.serverURL=http:/bigbluebutton.web.serverURL=https:/g' "$BBB_WEB_ETC_CONFIG"
   fi
 
-  yq -y -i '.playback_protocol = "https"' /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
+  yq-go e -i '.playback_protocol = "https"' /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
   chmod 644 /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
 
   # Update Greenlight (if installed) to use SSL
@@ -1779,29 +1779,29 @@ fi
   TARGET=/etc/bigbluebutton/bbb-webrtc-sfu/production.yml
   touch $TARGET
 
-  yq -y -i ".freeswitch.ip = \"$IP\"" $TARGET
+  yq-go e -i ".freeswitch.ip = \"$IP\"" $TARGET
 
   if [[ $BIGBLUEBUTTON_RELEASE == 2.2.* ]] && [[ ${BIGBLUEBUTTON_RELEASE#*.*.} -lt 29 ]]; then
     if [ -n "$INTERNAL_IP" ]; then
-      yq -y -i ".freeswitch.sip_ip = \"$INTERNAL_IP\"" $TARGET
+      yq-go e -i ".freeswitch.sip_ip = \"$INTERNAL_IP\"" $TARGET
     else
-      yq -y -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
+      yq-go e -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
     fi
   else
     # Use nginx as proxy for WSS -> WS (see https://github.com/bigbluebutton/bigbluebutton/issues/9667)
-    yq -y -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
+    yq-go e -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
   fi
   chown bigbluebutton:bigbluebutton $TARGET
   chmod 644 $TARGET
 
   # Configure mediasoup IPs, reference: https://raw.githubusercontent.com/bigbluebutton/bbb-webrtc-sfu/v2.7.2/docs/mediasoup.md
   # mediasoup IPs: WebRTC
-  yq -y -i '.mediasoup.webrtc.listenIps[0].ip = "0.0.0.0"' $TARGET
-  yq -y -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
+  yq-go e -i '.mediasoup.webrtc.listenIps[0].ip = "0.0.0.0"' $TARGET
+  yq-go e -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
 
   # mediasoup IPs: plain RTP (internal comms, FS <-> mediasoup)
-  yq -y -i '.mediasoup.plainRtp.listenIp.ip = "0.0.0.0"' $TARGET
-  yq -y -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
+  yq-go e -i '.mediasoup.plainRtp.listenIp.ip = "0.0.0.0"' $TARGET
+  yq-go e -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
 
   systemctl reload nginx
 }

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -303,8 +303,8 @@ main() {
   get_IP "$HOST"
 
   #need_ppa martin-uni-mainz-ubuntu-coturn-noble.list ppa:martin-uni-mainz/coturn  4B77C2225D3BBDB3 # Coturn
-  need_ppa martin-uni-mainz-ubuntu-yq-go-noble.list ppa:martin-uni-mainz/yq-go 4B77C2225D3BBDB3 # Edit yaml files with debian's yq-go (mikefarah/yq syntax BBB 3.0 used rather than kislyuk syntax used by the yq tool included in Ubuntu 24.04)
-  need_pkg wget curl gpg-agent dirmngr apparmor-utils ca-certificates ruby apt-transport-https haveged openjdk-17-jre dnsutils yq-go
+  #need_ppa martin-uni-mainz-ubuntu-yq-go-noble.list ppa:martin-uni-mainz/yq-go 4B77C2225D3BBDB3 # Edit yaml files with debian's yq-go (mikefarah/yq syntax BBB 3.0 used rather than kislyuk syntax used by the yq tool included in Ubuntu 24.04)
+  need_pkg wget curl gpg-agent dirmngr apparmor-utils ca-certificates ruby apt-transport-https haveged openjdk-17-jre dnsutils bbb-yq-go
 
   if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
     sudo mkdir -p /etc/apt/keyrings

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -680,14 +680,15 @@ need_pkg() {
 
 need_ppa() {
   need_pkg software-properties-common
-  if [ ! -f "/etc/apt/sources.list.d/$1" ]; then
+  # On Ubuntu 24.04, add-apt-repository writes a deb822 *.sources file and keeps the PPA
+  # signing key in its own keyring. apt-key is deprecated and its keyring is empty on noble,
+  # so gate on the sources file add-apt-repository creates instead of `apt-key list "$3"`.
+  local base="/etc/apt/sources.list.d/${1%.list}"
+  if [ ! -f "$base.sources" ] && [ ! -f "$base.list" ]; then
     LC_CTYPE=C.UTF-8 add-apt-repository -y "$2"
   fi
-  if ! apt-key list "$3" | grep -q -E "1024|4096"; then  # Let's try it a second time
-    LC_CTYPE=C.UTF-8 add-apt-repository "$2" -y
-    if ! apt-key list "$3" | grep -q -E "1024|4096"; then
-      err "Unable to setup PPA for $2"
-    fi
+  if [ ! -f "$base.sources" ] && [ ! -f "$base.list" ]; then
+    err "Unable to setup PPA for $2"
   fi
 }
 


### PR DESCRIPTION
* In this PR we're switching back to mikefarah syntax but invoking `yq-go`, now added via `bbb-yq-go` package from BigBlueButton's packages repository.

`bbb-yq-go` (packaging mikefarah/yq binary from https://github.com/mikefarah/yq/releases) matches the mikefarah/yq syntax BigBlueButton relied on in previous BBB iterations under the name `yq`. When upgrading to Ubuntu 24.04 in #826 we tried adopting the tool called `yq` already present in Ubuntu 24.04. However, the syntax was different (overcome in #826 and https://github.com/bigbluebutton/bigbluebutton/pull/24805) and the behavior turned out to not be identical either.



* I am including here a tweak to `need_ppa` as it was causing `apt-key` complaints and errors - discovered during the work on the PR
```
Reading package lists...
Repository: 'Types: deb
URIs: https://ppa.launchpadcontent.net/martin-uni-mainz/yq-go/ubuntu/
Suites: noble
Components: main
'
Description:
yq go builds and it build dependencies
More info: https://launchpad.net/~martin-uni-mainz/+archive/ubuntu/yq-go
Adding repository.
Found existing deb entry in /etc/apt/sources.list.d/martin-uni-mainz-ubuntu-yq-go-noble.sources
+ apt-key list 4B77C2225D3BBDB3
+ grep -q -E '1024|4096'
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
+ err 'Unable to setup PPA for ppa:martin-uni-mainz/yq-go'
+ say 'Unable to setup PPA for ppa:martin-uni-mainz/yq-go'
+ echo 'bbb-install: Unable to setup PPA for ppa:martin-uni-mainz/yq-go'
bbb-install: Unable to setup PPA for ppa:martin-uni-mainz/yq-go
+ exit 1
Error: Process completed with exit code 1.
```

Note, this matches bigbluebutton/bigbluebutton PR https://github.com/bigbluebutton/bigbluebutton/pull/25398

Many thanks to @christmart who ported yq-go from Debian into a launchpad ppa. Initially I adopted that ppa but decided it's best for the project to be in control of which `yq` version we're using. See https://github.com/bigbluebutton/bigbluebutton/pull/25398 for our packaging.
