### PR TITLE
4.0: install Node 24 from NodeSource

### DIFF
--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -304,13 +304,15 @@ main() {
 
   need_pkg wget curl gpg-agent dirmngr apparmor-utils ca-certificates ruby apt-transport-https haveged openjdk-21-jre dnsutils bbb-yq-go
 
-  if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
+  NODE_MAJOR=24
+  # Rewrite the NodeSource repo whenever it points at any other Node major (upgrade
+  # path from servers installed with Node <= 22), not only when it is absent.
+  if ! grep -qs "deb.nodesource.com/node_$NODE_MAJOR.x" /etc/apt/sources.list.d/nodesource.list; then
     sudo mkdir -p /etc/apt/keyrings
     if [ -f /etc/apt/keyrings/nodesource.gpg ]; then
       rm /etc/apt/keyrings/nodesource.gpg
     fi
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-    NODE_MAJOR=24
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
   fi
 

--- a/bbb-install.sh
+++ b/bbb-install.sh
@@ -310,7 +310,7 @@ main() {
       rm /etc/apt/keyrings/nodesource.gpg
     fi
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-    NODE_MAJOR=22
+    NODE_MAJOR=24
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
   fi
 


### PR DESCRIPTION
Companion to the bigbluebutton 40-nodejs-24 branch, whose debs will require nodejs (>= 24) (<< 25). Node 22 leaves maintenance 2027-04-30, during 4.0 lifetime; Node 24 is Active LTS (maintained until 2028-04-30). Must ship together with packages built against Node 24 - old debs (nodejs << 23) are not installable once this repo change is in place.